### PR TITLE
Multi-stage build in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,24 @@
 FROM ubuntu:jammy
 
 RUN apt update && apt upgrade -y
-RUN apt install -y openjdk-18-jre-headless nginx patch
+RUN apt install -y openjdk-18-jre-headless
 
 COPY . /app
 WORKDIR /app
 
-RUN patch -d / -p0 < nginx-default.patch
+RUN ./gradlew distTar --no-daemon
 
-RUN ./gradlew build --no-daemon
-CMD nginx && ./gradlew run --no-daemon
+FROM ubuntu:jammy
+
+RUN apt update && apt upgrade -y
+RUN apt install -y openjdk-18-jre-headless nginx patch
+
+WORKDIR /app
+
+COPY --from=0 /app/nginx-default.patch /app
+RUN patch -d / -p0 < nginx-default.patch && rm nginx-default.patch
+
+COPY --from=0 /app/build/distributions/traktor-streaming-proxy.tar /app
+RUN tar xf traktor-streaming-proxy.tar --strip-components=1 && rm traktor-streaming-proxy.tar
+
+CMD nginx && bin/traktor-streaming-proxy


### PR DESCRIPTION
This runs the server without gradle, removes gradle build files inside the container and decrease image size