### PR TITLE
Add OAuth support for Spotify

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 
     implementation("com.github.teamnewpipe.NewPipeExtractor:extractor:v0.23.1")
 
-    implementation("xyz.gianlu.librespot:librespot-lib:1.6.3")
+    implementation("xyz.gianlu.librespot:librespot-lib:1.6.4")
     implementation("org.json:json:20230227")
 
     implementation("com.tiefensuche:tidal-kt:0.2.0")

--- a/config.properties
+++ b/config.properties
@@ -9,10 +9,6 @@ sources.enabled=youtube
 # leave empty if you want to use all
 search.enabled=
 
-# if you enable spotify, you need to fill in your login credentials
-spotify.username=username
-spotify.password=password
-
 # if you enable tidal, you need to fill in your client id
 # you need your account credentials when asked to visit the authentication web page
 tidal.clientId=client_id


### PR DESCRIPTION
Authentication with username and password no longer works. Bump librespot-lib to 1.6.4 and use OAuth instead.

Fixes #19 