### PR TITLE
Add endpoint and models for the new beatport search API

### DIFF
--- a/src/main/kotlin/beatport/api/Data.kt
+++ b/src/main/kotlin/beatport/api/Data.kt
@@ -47,3 +47,24 @@ data class CuratedPlaylistResponse(val results: List<PlaylistItem>, val next: St
 
 @Serializable
 data class Download(val location: String, val stream_quality: String, val length_ms: Int)
+
+// --- New models for the Beatport Search API response ---
+
+@Serializable
+data class BeatportSearchResponse(
+    val data: List<BeatportTrack>
+)
+
+@Serializable
+data class BeatportTrack(
+    val track_id: Long,
+    val artists: List<BeatportArtist>,
+    val track_name: String,
+    val length: Long,
+)
+
+@Serializable
+data class BeatportArtist(
+    val artist_name: String,
+    val artist_type_name: String // Required by traktor
+)


### PR DESCRIPTION
Fixes #44 

Traktor Pro 4.2.0 uses a new, undocumented, Beatport search API, which likely uses Elasticsearch on the backend for better results.

https://support.native-instruments.com/hc/en-us/articles/360017233958-What-s-new-in-Traktor-Pro-4-2-0

> Search on Beatport and Beatsource has had an upgrade to improve speed and offer smarter processing of two word searches.

The new models used in this new response are the bare minimum needed to get search working.

What's not working yet: Paginated results. It's still unclear what query parameters are needed to support multiple pages of results, and therefore this search now results only 15 results.

