### PR TITLE
Fix YouTube downloads by updating NewPipeExtractor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,25 +10,31 @@ repositories {
 }
 
 dependencies {
-    val ktor_version = "3.1.3"
-    implementation("io.ktor:ktor-server-core-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-netty-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-status-pages-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-default-headers-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-xml:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-cbor:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-protobuf:$ktor_version")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-server-call-logging:$ktor_version")
-    implementation("io.ktor:ktor-network-tls-certificates:$ktor_version")
+    val ktorVersion = "3.1.3"
+    implementation(enforcedPlatform("io.netty:netty-bom:4.1.137.Final"))
+    implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-status-pages-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-default-headers-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-xml:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-cbor:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-protobuf:$ktorVersion")
+    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+    implementation("io.ktor:ktor-server-call-logging:$ktorVersion")
+    implementation("io.ktor:ktor-network-tls-certificates:$ktorVersion")
     implementation("org.slf4j:slf4j-log4j12:2.0.6")
 
-    implementation("com.github.teamnewpipe.NewPipeExtractor:extractor:v0.24.8")
+    implementation("com.github.teamnewpipe:NewPipeExtractor:v0.26.4")
     implementation("com.github.librespot-org.librespot-java:librespot-lib:52a8c24215")
     implementation("com.github.0xf4b1:spotify-kt:275f290e64")
     implementation("com.github.0xf4b1:tidal-kt:v0.3.1")
+
+    // Patched transitive protobuf version (IDE Mend warning).
+    constraints {
+        implementation("com.google.protobuf:protobuf-java:3.25.9")
+    }
 
     testImplementation(kotlin("test"))
     implementation(kotlin("stdlib-jdk8"))

--- a/src/main/kotlin/sources/Youtube.kt
+++ b/src/main/kotlin/sources/Youtube.kt
@@ -6,8 +6,9 @@ import org.schabi.newpipe.extractor.downloader.Request
 import org.schabi.newpipe.extractor.downloader.Response
 import org.schabi.newpipe.extractor.localization.Localization
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.MUSIC_SONGS
+import org.schabi.newpipe.extractor.stream.DeliveryMethod
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
-import java.net.URL
+import java.net.URI
 import java.util.*
 
 class Youtube : ISource {
@@ -64,7 +65,7 @@ class Youtube : ISource {
     }
 
     private fun downloadTrack(path: String): ByteArray {
-        val con = URL(path).openConnection()
+        val con = URI.create(path).toURL().openConnection()
         con.setRequestProperty("range", "bytes=0-")
         return con.inputStream.readBytes()
     }
@@ -88,16 +89,23 @@ class Youtube : ISource {
     private fun getAudioStream(url: String): String {
         val extractor = ServiceList.YouTube.getStreamExtractor("https://www.youtube.com/watch?v=$url")
         extractor.fetchPage()
-        return extractor.audioStreams.filter { it.format!!.name == "m4a" }.maxBy { it.averageBitrate }.content
+        val m4a = extractor.audioStreams.filter { it.format?.name == "m4a" && it.isUrl }
+        // Prefer progressive HTTP when available; fall back to highest-bitrate m4a URL.
+        val stream = m4a
+            .filter { it.deliveryMethod == DeliveryMethod.PROGRESSIVE_HTTP }
+            .maxByOrNull { it.averageBitrate }
+            ?: m4a.maxByOrNull { it.averageBitrate }
+            ?: throw IllegalStateException("No m4a audio stream for YouTube id=$url")
+        return stream.content
     }
 
     class Downloader : org.schabi.newpipe.extractor.downloader.Downloader() {
 
-        private val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:68.0) Gecko/20100101 Firefox/68.0"
+        private val userAgent = "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:68.0) Gecko/20100101 Firefox/68.0"
 
         override fun execute(request: Request): Response {
             val headers = HashMap<String, String>()
-            headers["User-Agent"] = USER_AGENT
+            headers["User-Agent"] = userAgent
             request.headers().forEach { (k, v) -> headers[k] = v[0]}
 
             val con = WebRequests.createConnection(request.url(), request.httpMethod(), headers)


### PR DESCRIPTION
## Problem
YouTube track downloads were broken with the current NewPipeExtractor (v0.24.8). YouTube regularly changes stream/player APIs, so the extractor could no longer resolve usable audio URLs — search might still work, but loading a track failed at download time.
The stream-selection logic was also brittle: it assumed every m4a entry had a format and a direct URL, and it did not prefer progressive HTTP over other delivery methods. That made failures noisier and less reliable even when a usable stream was available.

## Summary
•Update NewPipeExtractor to v0.26.4 so extraction works with current YouTube APIs.
•Prefer progressive HTTP m4a streams when available, with a bitrate fallback and a clear error if none are found.
•Pin patched transitive Netty (4.1.137.Final BOM) and protobuf-java (3.25.9) versions to clear related IDE/security warnings.

## Test plan
- [x] Enable YouTube in sources.enabled / search.enabled
- [x] Search for a track in Traktor and confirm results appear
- [x] Load a YouTube track and confirm audio downloads/plays
- [x] Confirm ./gradlew build (or at least compile) succeeds with the new dependency coordinates

## Relation to other open PRs
This overlaps with #54 and #58 on the NewPipeExtractor bump, but the YouTube fix here is intentionally smaller and more targeted:

- Bumps NewPipeExtractor to `v0.26.4` (same generation as #58; newer than #54's `v0.26.1`).
- Prefers progressive HTTP m4a streams when available, then falls back to the highest-bitrate m4a URL, instead of only `maxBy` / first m4a.
- Avoids broader SSL/port changes (#54) and the larger YouTube playlist/OAuth rewrite (#58).

Happy to rebase or adjust if maintainers prefer one of those larger PRs as the base.