### PR TITLE
Add macOS launchers and ignore local build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ cert/keystore.*
 cert/server.*
 
 .idea
+/.gradle/
+/build/
+cert/*.dylib
+
+# local secrets (use src/main/dist/config.properties as template)
+/config.properties

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ If you get an error or something different, it will not work with Traktor and yo
 DYLD_INSERT_LIBRARIES=./SecTrustEvaluateStub.dylib "/Applications/Native Instruments/Traktor Pro 3/Traktor.app/Contents/MacOS/Traktor"
 ```
 
+If you built from source (`./gradlew installDist`) and have `cert/SecTrustEvaluateStub.dylib`, you can instead double-click `start-traktor-proxy.command` to start the proxy from the repo-root `config.properties`, launch Traktor with the stub library, and stop the proxy when Traktor quits. Use `stop-traktor-proxy.command` to stop the proxy manually. Override the Traktor binary path with `TRAKTOR_BIN` if needed.
+
 If you are not yet linked with the server, open settings and connect to Beatport streaming. You should receive an immediate redirect which connects Traktor.
 
 10. Done! If you navigate to Beatport Streaming, you should be able to browse through the predefined categories and use the search box to find content.

--- a/start-traktor-proxy.command
+++ b/start-traktor-proxy.command
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Double-clickable launcher: starts the streaming proxy (if needed), then Traktor
+# with SecTrustEvaluateStub.dylib preloaded. Stops the proxy when Traktor quits
+# (only if this script started it).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+PROXY_DIR="$ROOT/build/install/traktor-streaming-proxy"
+PROXY_BIN="$PROXY_DIR/bin/traktor-streaming-proxy"
+DYLIB="$ROOT/cert/SecTrustEvaluateStub.dylib"
+TRAKTOR="${TRAKTOR_BIN:-/Applications/Native Instruments/Traktor Pro 4/Traktor Pro 4.app/Contents/MacOS/Traktor Pro 4}"
+LOG="${TRAKTOR_PROXY_LOG:-$HOME/Library/Logs/traktor-streaming-proxy.log}"
+
+STARTED_PROXY=0
+PROXY_PID=""
+
+if [[ ! -x "$PROXY_BIN" ]]; then
+  echo "Proxy binary not found: $PROXY_BIN"
+  echo "Build it first: ./gradlew installDist"
+  read -r -p "Press Enter to close..."
+  exit 1
+fi
+
+if [[ ! -f "$DYLIB" ]]; then
+  echo "Stub library not found: $DYLIB"
+  echo "Build it with: (cd cert && make)"
+  read -r -p "Press Enter to close..."
+  exit 1
+fi
+
+if [[ ! -x "$TRAKTOR" ]]; then
+  echo "Traktor binary not found: $TRAKTOR"
+  echo "Set TRAKTOR_BIN to the correct path if needed."
+  read -r -p "Press Enter to close..."
+  exit 1
+fi
+
+# Probe only the local proxy process on :8443.
+# Use localhost (often ::1): on some macOS/Java setups 127.0.0.1:8443 times out while
+# the IPv6 listener works. Never fall back to system DNS for api.beatport.com — that can
+# hit the real Beatport API and look "ready" even when this proxy is down.
+proxy_ready() {
+  local body
+  body="$(curl --noproxy '*' -sk --fail --connect-timeout 1 --max-time 2 \
+    "https://localhost:8443/v4/catalog/genres/" 2>/dev/null)" || return 1
+  printf '%s' "$body" | grep -Eq '"results"[[:space:]]*:[[:space:]]*\['
+}
+
+stop_proxy() {
+  if [[ "$STARTED_PROXY" -ne 1 ]]; then
+    return 0
+  fi
+  echo "Stopping traktor-streaming-proxy..."
+  if [[ -n "$PROXY_PID" ]] && kill -0 "$PROXY_PID" 2>/dev/null; then
+    kill "$PROXY_PID" 2>/dev/null || true
+    # Wait briefly, then force if still alive
+    for _ in $(seq 1 20); do
+      if ! kill -0 "$PROXY_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 0.25
+    done
+    if kill -0 "$PROXY_PID" 2>/dev/null; then
+      kill -9 "$PROXY_PID" 2>/dev/null || true
+    fi
+  fi
+  # Fallback: anything still matching the installed binary path
+  pkill -f "$PROXY_BIN" 2>/dev/null || true
+  STARTED_PROXY=0
+  echo "Proxy stopped."
+}
+
+trap stop_proxy EXIT
+
+# Config.readConfig() loads ./config.properties from the process CWD.
+# Use the repo-root config, not the installDist template.
+CONFIG_FILE="$ROOT/config.properties"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "config.properties not found in $ROOT"
+  read -r -p "Press Enter to close..."
+  exit 1
+fi
+
+if ! proxy_ready; then
+  echo "Starting traktor-streaming-proxy..."
+  echo "Config: $CONFIG_FILE"
+  echo "Log: $LOG"
+  cd "$ROOT"
+  nohup "$PROXY_BIN" >>"$LOG" 2>&1 &
+  PROXY_PID=$!
+  STARTED_PROXY=1
+
+  ready=0
+  for _ in $(seq 1 60); do
+    if proxy_ready; then
+      ready=1
+      break
+    fi
+    sleep 0.5
+  done
+
+  if [[ "$ready" -ne 1 ]]; then
+    echo "Proxy did not become ready in time on https://localhost:8443. Check $LOG"
+    echo "Traktor still needs pf redirect + /etc/hosts for api.beatport.com:443."
+    read -r -p "Press Enter to close..."
+    exit 1
+  fi
+  echo "Proxy is ready (pid $PROXY_PID)."
+else
+  echo "Proxy already running (will not stop it on exit)."
+fi
+
+echo "Launching Traktor..."
+export DYLD_INSERT_LIBRARIES="$DYLIB"
+# Do not exec: keep this shell alive so trap can stop the proxy after Traktor quits.
+"$TRAKTOR"
+echo "Traktor closed."

--- a/stop-traktor-proxy.command
+++ b/stop-traktor-proxy.command
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Stop traktor-streaming-proxy if it is running.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+PROXY_BIN="$ROOT/build/install/traktor-streaming-proxy/bin/traktor-streaming-proxy"
+
+stopped=0
+
+if [[ -x "$PROXY_BIN" ]] && pgrep -f "$PROXY_BIN" >/dev/null 2>&1; then
+  pkill -f "$PROXY_BIN" 2>/dev/null || true
+  stopped=1
+fi
+
+# Also match java processes started from the install dist (Gradle wrapper may exec java)
+if pgrep -f "traktor-streaming-proxy.jar" >/dev/null 2>&1; then
+  pkill -f "traktor-streaming-proxy.jar" 2>/dev/null || true
+  stopped=1
+fi
+
+# Brief wait + force leftover listeners on 8443 owned by our app name
+sleep 0.5
+if pgrep -f "traktor-streaming-proxy" >/dev/null 2>&1; then
+  pkill -9 -f "traktor-streaming-proxy" 2>/dev/null || true
+  stopped=1
+fi
+
+if [[ "$stopped" -eq 1 ]]; then
+  echo "traktor-streaming-proxy stopped."
+else
+  echo "traktor-streaming-proxy is not running."
+fi


### PR DESCRIPTION
## Problem
Starting the proxy and Traktor locally on macOS is still a multi-step manual flow: build/installDist, start the proxy with the right config.properties, preload SecTrustEvaluateStub.dylib, and remember to stop the proxy afterward. That is easy to get wrong and slows day-to-day use after a source build.
A naive health check against api.beatport.com is also unsafe: system DNS can hit the real Beatport API and report “ready” even when this proxy is down.
Local Gradle output, the compiled trust stub (.dylib), and a filled-in config.properties also tend to show up as untracked noise in the working tree.

## Summary
•Add double-clickable start-traktor-proxy.command: start the proxy from repo-root config.properties if needed, wait until https://localhost:8443 serves the genres payload, launch Traktor with the trust stub, and stop the proxy on exit (only if this script started it).
•Add stop-traktor-proxy.command for manual shutdown.
•Document both launchers in the README, including TRAKTOR_BIN override.
•Ignore /.gradle/, /build/, cert/*.dylib, and repo-root /config.properties.

## Test plan
- [x] ./gradlew installDist and build cert/SecTrustEvaluateStub.dylib
- [x] Double-click start-traktor-proxy.command with proxy stopped → proxy starts, Traktor launches
- [x] Quit Traktor → proxy started by the script stops
- [x] Run the launcher with proxy already running → Traktor launches, existing proxy is left running
- [x] Double-click stop-traktor-proxy.command → proxy process stops
- [x] Confirm health check fails cleanly when the proxy is down (does not treat public Beatport as ready)
- [x] Confirm git status does not list .gradle/, build/, cert/*.dylib, or local config.properties

## Note
`.gitignore` overlap with #54/#58 is intentional and minimal (`/.gradle/`, `/build/`, trust-stub artifacts). The main addition here is the macOS `.command` launchers.