### PR TITLE
Improve source startup reporting and search.enabled defaults

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -53,11 +53,14 @@ object Config {
     }
 }
 
-fun register(source: Class<out ISource>) {
-    try {
+fun register(source: Class<out ISource>): Boolean {
+    return try {
         sources.add(source.getConstructor().newInstance())
+        true
     } catch (ex: Exception) {
-        println("Can not instantiate $source: ${ex.printStackTrace()}")
+        println("Can not instantiate $source: ${ex.message}")
+        ex.printStackTrace()
+        false
     }
 }
 
@@ -86,7 +89,7 @@ private fun executeSearch(q: String, hasMoreParameter: Boolean): List<TrackRespo
         query = actualQuery
         listOf(allSources[sourceName])
     } else {
-        prop.getProperty("search.enabled", "").split(",").map { name -> allSources[name] }
+        parseSearchEnabledSources(prop.getProperty("search.enabled", ""))
     }
 
     return sources.mapIndexed { id, source ->
@@ -96,6 +99,18 @@ private fun executeSearch(q: String, hasMoreParameter: Boolean): List<TrackRespo
             emptyList()
         }
     }.flatten()
+}
+
+/**
+ * Parses `search.enabled`. Blank / empty list means all sources (null sentinel),
+ * matching the historical `"".split(",")` → `[null]` behavior.
+ */
+internal fun parseSearchEnabledSources(raw: String): List<Class<out ISource>?> {
+    val names = raw.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+    if (names.isEmpty()) {
+        return listOf(null)
+    }
+    return names.map { name -> allSources[name] }
 }
 
 fun main() {
@@ -108,10 +123,22 @@ fun main() {
         }
     })
 
-    prop.getProperty("sources.enabled", "").split(",").map { name -> allSources[name] }.forEach {
-        if (it != null)
-            register(it)
+    val enabled = prop.getProperty("sources.enabled", "").split(",").map { it.trim() }.filter { it.isNotEmpty() }
+    println("Enabled sources: ${enabled.joinToString(", ").ifEmpty { "(none)" }}")
+    enabled.forEach { name ->
+        val clazz = allSources[name]
+        if (clazz != null) {
+            println("Initializing ${clazz.simpleName}...")
+            if (register(clazz)) {
+                println("Initialized ${clazz.simpleName}")
+            } else {
+                println("Failed to initialize ${clazz.simpleName}")
+            }
+        } else {
+            println("Unknown source '$name' in sources.enabled (skipped)")
+        }
     }
+    println("Registered ${sources.size} source(s): ${sources.joinToString { it.name }}")
 
     val alias = "foo"
     var serverConfiguration: NettyApplicationEngine.Configuration.() -> Unit
@@ -147,6 +174,7 @@ fun main() {
         }
     }
 
+    println("Starting HTTPS server on port 8443...")
     embeddedServer(Netty, applicationEnvironment(), serverConfiguration, module = {
         install(CallLogging)
         install(ContentNegotiation) {
@@ -266,7 +294,9 @@ fun main() {
                 call.respondBytes(data)
             }
         }
-    }).start(wait = true)
+    }).start(wait = false)
+    println("Listening on https://api.beatport.com:8443. Ctrl+C to stop.")
+    Thread.currentThread().join()
 }
 
 private fun List<TrackResponse>.toNewSearchApi(): List<BeatportTrack> {

--- a/src/test/kotlin/MainLogicTest.kt
+++ b/src/test/kotlin/MainLogicTest.kt
@@ -1,0 +1,21 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MainLogicTest {
+
+    @Test
+    fun parseSearchEnabledSources_blankMeansAll() {
+        assertEquals(listOf(null), parseSearchEnabledSources(""))
+        assertEquals(listOf(null), parseSearchEnabledSources("   "))
+        assertEquals(listOf(null), parseSearchEnabledSources(", ,"))
+    }
+
+    @Test
+    fun parseSearchEnabledSources_trimsAndResolves() {
+        assertEquals(listOf(allSources["youtube"]), parseSearchEnabledSources(" youtube "))
+        assertEquals(
+            listOf(allSources["youtube"], allSources["spotify"]),
+            parseSearchEnabledSources("youtube, spotify")
+        )
+    }
+}


### PR DESCRIPTION
## Problem
With a blank or whitespace-only search.enabled, the old split/map path did not reliably keep the historical “search all sources” behavior, and spaced names like youtube, spotify could fail to resolve.
Source initialization was also quiet and inaccurate: failed register() calls still looked like success, unknown sources.enabled entries were skipped silently, and after ./gradlew run the process often appeared hung until the first request because nothing printed that the HTTPS server was listening.

## Summary
•Parse search.enabled so blank/empty means all sources, and trim explicit source names.
•Make register() return success/failure and print clear init / failure / unknown-source messages.
•Print start/listen banners and keep the process alive with start(wait = false) + join so local runs show that the server is up.
•Add unit tests for parseSearchEnabledSources.

## Test plan
- [x] ./gradlew test --tests MainLogicTest
- [x] Run with blank search.enabled and confirm search hits all enabled sources
- [x] Run with search.enabled= youtube , spotify  and confirm only those sources are used
- [x] Put an unknown name in sources.enabled and confirm it is reported and skipped
- [x] ./gradlew run and confirm console shows init progress plus a listening banner before any request