### PR TITLE
Harden Traktor track ID mapping against collisions

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -20,14 +20,118 @@ import sources.Youtube
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.nio.charset.StandardCharsets
 import java.security.KeyStore
+import java.security.MessageDigest
 import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.math.min
 
 val sources: ArrayList<ISource> = ArrayList()
-val trackIdToSource: HashMap<String, Int> = HashMap()
-val traktorIdToTrackId: HashMap<Long, String> = HashMap()
+
+private const val ENCODE_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_"
+private const val TRACK_MAPPING_MAX = 8192
+
+/**
+ * Thread-safe Traktor id mappings with LRU eviction.
+ * Allocation check-and-claim is atomic; [trackIds]/[sources]/[tracks] stay in sync.
+ */
+internal class TrackMappings(
+    private val maxSize: Int = TRACK_MAPPING_MAX
+) {
+    private val lock = Any()
+    private val trackIds = LinkedHashMap<Long, String>(16, 0.75f, true)
+    private val sources = HashMap<Long, Int>()
+    private val tracks = HashMap<Long, TrackResponse>()
+
+    init {
+        require(maxSize > 0) { "maxSize must be positive" }
+    }
+
+    fun allocate(sourceId: Int, fullId: String): Long = synchronized(lock) {
+        allocateLocked(sourceId, fullId)
+    }
+
+    fun register(sourceId: Int, track: Track): TrackResponse = synchronized(lock) {
+        val traktorId = allocateLocked(sourceId, track.id)
+        TrackResponse(traktorId, track.artists, track.name, track.length_ms).also {
+            tracks[traktorId] = it
+        }
+    }
+
+    fun getTrack(traktorId: Long): TrackResponse? = synchronized(lock) {
+        // LinkedHashMap get refreshes LRU order; containsKey would not.
+        trackIds[traktorId] ?: return null
+        tracks[traktorId]
+    }
+
+    fun resolve(traktorId: Long): Pair<String, Int>? = synchronized(lock) {
+        val trackId = trackIds[traktorId] ?: return null
+        val sourceId = sources[traktorId] ?: return null
+        trackId to sourceId
+    }
+
+    fun getTrackId(traktorId: Long): String? = synchronized(lock) {
+        trackIds[traktorId]
+    }
+
+    fun getSource(traktorId: Long): Int? = synchronized(lock) {
+        sources[traktorId]
+    }
+
+    fun remove(traktorId: Long) = synchronized(lock) {
+        trackIds.remove(traktorId)
+        sources.remove(traktorId)
+        tracks.remove(traktorId)
+    }
+
+    fun size(): Int = synchronized(lock) {
+        trackIds.size
+    }
+
+    private fun allocateLocked(sourceId: Int, fullId: String): Long {
+        val preferredPrefix = fullId.substring(0, min(fullId.length, 10))
+        if (preferredPrefix.all { it in ENCODE_ALPHABET }) {
+            val preferred = Utils.encode(preferredPrefix)
+            val existingTrackId = trackIds[preferred]
+            val existingSourceId = sources[preferred]
+            if (existingTrackId == null || (existingTrackId == fullId && existingSourceId == sourceId)) {
+                claimLocked(preferred, sourceId, fullId)
+                return preferred
+            }
+        }
+
+        val sourceQualifiedId = "$sourceId:$fullId"
+        for (salt in 0 until 1024) {
+            val key = Utils.encode(hashToEncodableKey(sourceQualifiedId, salt))
+            val existingTrackId = trackIds[key]
+            val existingSourceId = sources[key]
+            if (existingTrackId == null || (existingTrackId == fullId && existingSourceId == sourceId)) {
+                claimLocked(key, sourceId, fullId)
+                return key
+            }
+        }
+        throw IllegalStateException("Could not allocate Traktor id for source $sourceId track $fullId")
+    }
+
+    private fun claimLocked(traktorId: Long, sourceId: Int, fullId: String) {
+        trackIds[traktorId] = fullId
+        sources[traktorId] = sourceId
+        trimToMaxSizeLocked()
+    }
+
+    private fun trimToMaxSizeLocked() {
+        val iterator = trackIds.entries.iterator()
+        while (trackIds.size > maxSize && iterator.hasNext()) {
+            val eldest = iterator.next()
+            iterator.remove()
+            sources.remove(eldest.key)
+            tracks.remove(eldest.key)
+        }
+    }
+}
+
+internal val trackMappings = TrackMappings()
 
 val allSources = mapOf(
     "youtube" to Youtube::class.java,
@@ -61,15 +165,34 @@ fun register(source: Class<out ISource>) {
     }
 }
 
-fun processTracks(id: Int, tracks: List<Track>): List<TrackResponse> {
-    return tracks.map { track ->
-        trackIdToSource[track.id] = id
-        val traktorId = Utils.encode(track.id.substring(0, min(track.id.length, 10)))
-        if (!traktorIdToTrackId.containsKey(traktorId)) {
-            traktorIdToTrackId[traktorId] = if (track.id.length > 10) track.id.substring(10) else ""
-        }
-        TrackResponse(traktorId, track.artists, track.name, track.length_ms)
+/**
+ * Builds a 10-char key in the [Utils.encode] alphabet from [fullId].
+ * [salt] is mixed in so callers can probe on rare hash collisions.
+ */
+internal fun hashToEncodableKey(fullId: String, salt: Int = 0): String {
+    val md = MessageDigest.getInstance("SHA-256")
+    md.update(fullId.toByteArray(StandardCharsets.UTF_8))
+    if (salt != 0) {
+        md.update(salt.toString().toByteArray(StandardCharsets.UTF_8))
     }
+    val digest = md.digest()
+    return buildString(10) {
+        for (i in 0 until 10) {
+            append(ENCODE_ALPHABET[digest[i].toInt() and 63])
+        }
+    }
+}
+
+/**
+ * Allocates a unique Traktor id for [fullId] from [sourceId], storing both parts of the
+ * source-qualified identity. Different sources may legitimately expose the same raw track id.
+ * Prefers encoding the first 10 characters when free; on prefix collision uses a hash-based key.
+ */
+internal fun allocateTraktorId(sourceId: Int, fullId: String): Long =
+    trackMappings.allocate(sourceId, fullId)
+
+fun processTracks(id: Int, tracks: List<Track>): List<TrackResponse> {
+    return tracks.map { track -> trackMappings.register(id, track) }
 }
 
 /**
@@ -247,12 +370,31 @@ fun main() {
                 }
             }
 
-            get("/v4/catalog/tracks/{id}/download/") {
-                call.parameters["id"]?.let {
-                    val trackId = Utils.decode(it.toLong()) + traktorIdToTrackId[it.toLong()]!!
-                    data = sources[trackIdToSource[trackId]!!].download(trackId)
-                    call.respond(Download("https://api.beatport.com/output.mp4", "foo", 1337))
+            get("/v4/catalog/tracks/") {
+                // Avoid 404 when Traktor probes this URL; Search uses /search/v1/tracks with q.
+                call.respond(GenreTrackResponse(emptyList(), ""))
+            }
+
+            get("/v4/catalog/tracks/{id}/") {
+                call.parameters["id"]?.let { id ->
+                    val track = id.toLongOrNull()?.let { trackMappings.getTrack(it) }
+                    if (track != null) {
+                        call.respond(track)
+                    } else {
+                        call.respond(HttpStatusCode.NotFound)
+                    }
                 }
+            }
+
+            get("/v4/catalog/tracks/{id}/download/") {
+                val rawId = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+                val traktorId = rawId.toLongOrNull()
+                    ?: return@get call.respond(HttpStatusCode.BadRequest)
+                val resolved = trackMappings.resolve(traktorId)
+                    ?: return@get call.respond(HttpStatusCode.NotFound)
+                val (trackId, sourceId) = resolved
+                data = sources[sourceId].download(trackId)
+                call.respond(Download("https://api.beatport.com/output.mp4", "foo", 1337))
             }
 
             // Serve the last downloaded track

--- a/src/test/kotlin/MainLogicTest.kt
+++ b/src/test/kotlin/MainLogicTest.kt
@@ -1,0 +1,136 @@
+import beatport.api.Artist
+import beatport.api.Track
+import beatport.api.Utils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+class MainLogicTest {
+
+    private fun cleanup(responses: List<beatport.api.TrackResponse>) {
+        responses.forEach { response ->
+            trackMappings.remove(response.id)
+        }
+    }
+
+    @Test
+    fun processTracks_cachesTrackResponse() {
+        val track = Track("abcdefghij", listOf(Artist(1, "Artist")), "Name", 1234L)
+        val responses = processTracks(0, listOf(track))
+        try {
+            assertEquals(1, responses.size)
+            val cached = trackMappings.getTrack(responses[0].id)
+            assertEquals(responses[0], cached)
+            assertEquals("Name", cached!!.name)
+            assertEquals(0, trackMappings.getSource(responses[0].id))
+            assertEquals(track.id, trackMappings.getTrackId(responses[0].id))
+        } finally {
+            cleanup(responses)
+        }
+    }
+
+    @Test
+    fun processTracks_storesFullTrackIdBeyondTenChars() {
+        val track = Track("abcdefghijEXTRA", listOf(Artist(1, "A")), "Long", 1L)
+        val responses = processTracks(1, listOf(track))
+        try {
+            assertEquals(1, responses.size)
+            assertEquals(track.id, trackMappings.getTrackId(responses[0].id))
+            assertEquals(1, trackMappings.getSource(responses[0].id))
+            // Preferred path still encodes the first 10 chars when free
+            assertEquals(Utils.encode("abcdefghij"), responses[0].id)
+        } finally {
+            cleanup(responses)
+        }
+    }
+
+    @Test
+    fun processTracks_avoidsPrefixCollisions() {
+        val a = Track("12345678901", listOf(Artist(1, "A")), "One", 1L)
+        val b = Track("12345678902", listOf(Artist(1, "B")), "Two", 2L)
+        val responses = processTracks(0, listOf(a, b))
+        try {
+            assertEquals(2, responses.size)
+            assertNotEquals(responses[0].id, responses[1].id)
+            assertEquals(a.id, trackMappings.getTrackId(responses[0].id))
+            assertEquals(b.id, trackMappings.getTrackId(responses[1].id))
+            // First keeps preferred prefix encoding; second must use hash fallback
+            assertEquals(Utils.encode("1234567890"), responses[0].id)
+            assertNotEquals(Utils.encode("1234567890"), responses[1].id)
+        } finally {
+            cleanup(responses)
+        }
+    }
+
+    @Test
+    fun allocateTraktorId_reusesMappingForSameFullId() {
+        val id = "12345678901"
+        val first = allocateTraktorId(2, id)
+        val second = allocateTraktorId(2, id)
+        try {
+            assertEquals(first, second)
+            assertEquals(id, trackMappings.getTrackId(first))
+            assertEquals(2, trackMappings.getSource(first))
+        } finally {
+            trackMappings.remove(first)
+        }
+    }
+
+    @Test
+    fun processTracks_namespacesSameRawIdBySource() {
+        val firstTrack = Track("1234567890", listOf(Artist(1, "A")), "One", 1L)
+        val secondTrack = Track("1234567890", listOf(Artist(1, "B")), "Two", 2L)
+        val first = processTracks(0, listOf(firstTrack))
+        val second = processTracks(1, listOf(secondTrack))
+        val responses = first + second
+        try {
+            assertNotEquals(first.single().id, second.single().id)
+            assertEquals(0, trackMappings.getSource(first.single().id))
+            assertEquals(1, trackMappings.getSource(second.single().id))
+            assertEquals(firstTrack.id, trackMappings.getTrackId(first.single().id))
+            assertEquals(secondTrack.id, trackMappings.getTrackId(second.single().id))
+        } finally {
+            cleanup(responses)
+        }
+    }
+
+    @Test
+    fun trackMappings_evictsEldestWhenOverCapacity() {
+        val mappings = TrackMappings(maxSize = 2)
+        val first = mappings.register(0, Track("aaaaaaaaaa", listOf(Artist(1, "A")), "One", 1L))
+        val second = mappings.register(0, Track("bbbbbbbbbb", listOf(Artist(1, "B")), "Two", 2L))
+        val third = mappings.register(0, Track("cccccccccc", listOf(Artist(1, "C")), "Three", 3L))
+
+        assertEquals(2, mappings.size())
+        assertNull(mappings.getTrackId(first.id))
+        assertNull(mappings.getTrack(first.id))
+        assertEquals("bbbbbbbbbb", mappings.getTrackId(second.id))
+        assertEquals("cccccccccc", mappings.getTrackId(third.id))
+        assertEquals(second, mappings.getTrack(second.id))
+        assertEquals(third, mappings.getTrack(third.id))
+    }
+
+    @Test
+    fun trackMappings_accessRefreshesLruOrder() {
+        val mappings = TrackMappings(maxSize = 2)
+        val first = mappings.register(0, Track("aaaaaaaaaa", listOf(Artist(1, "A")), "One", 1L))
+        val second = mappings.register(0, Track("bbbbbbbbbb", listOf(Artist(1, "B")), "Two", 2L))
+        assertEquals(first, mappings.getTrack(first.id))
+
+        val third = mappings.register(0, Track("cccccccccc", listOf(Artist(1, "C")), "Three", 3L))
+        assertEquals(2, mappings.size())
+        assertEquals("aaaaaaaaaa", mappings.getTrackId(first.id))
+        assertNull(mappings.getTrackId(second.id))
+        assertEquals("cccccccccc", mappings.getTrackId(third.id))
+    }
+
+    @Test
+    fun hashToEncodableKey_isDeterministicAndEncodable() {
+        val key = hashToEncodableKey("12345678902")
+        assertEquals(10, key.length)
+        assertEquals(key, hashToEncodableKey("12345678902"))
+        assertNotEquals(key, hashToEncodableKey("12345678902", salt = 1))
+        assertEquals(key, Utils.decode(Utils.encode(key)))
+    }
+}


### PR DESCRIPTION
## Problem
Traktor track IDs are derived from only the first 10 characters of a source id, and the remainder is stored as a suffix keyed by that truncated id. When two tracks share the same prefix (common for numeric ids such as Tidal), the second track reuses the first mapping. Download then reconstructs the wrong source id (prefix + first suffix), so the wrong track is fetched or playback fails.
The old maps also keyed source lookup by raw track id with no source namespace, so identical ids from different providers could overwrite each other. The tables were unsynchronized and unbounded, which is unsafe under concurrent catalog traffic and long browse sessions.

## Summary
•Store the full source track id (and source index) per Traktor id instead of prefix + suffix.
•Prefer encoding the first 10 characters when free; on collision allocate a hash-based key.
•Namespace mappings by source so the same raw id from different providers does not collide.
•Make allocation/lookup thread-safe and bound the registry with LRU eviction (8192 entries).
•Resolve downloads through the mapping table; respond to /v4/catalog/tracks/ and /v4/catalog/tracks/{id}/.
•Add unit tests for collisions, source namespacing, reuse, and LRU behavior.

## Test plan
- [x] ./gradlew test --tests MainLogicTest
- [x] Search/browse tracks with long or sequential ids (e.g. Tidal) and confirm two prefix-colliding tracks get different Traktor ids and download the correct audio
- [x] Enable multiple sources, search for content, and confirm playback still resolves the right provider
- [x] Browse enough catalog pages to exercise many mappings and confirm the proxy keeps working without unbounded memory growth

## Relation to other open PRs
This addresses the same class of Traktor track-id collisions as #58's `TrackReferenceRegistry`, but with a different design trade-off:

- Keeps Beatport-style encoded IDs: prefer the first 10 chars when free, fall back to a hash-based key on collision.
- Namespaces by source so identical raw IDs from different providers do not overwrite each other.
- Uses an in-memory thread-safe LRU (8192) instead of a persistent on-disk registry.
- Does not change playlist ID encoding or introduce SoundCloud/audio-cache infrastructure from #58.

#54 still uses the old `decode(prefix) + suffix` path (with better errors); this PR replaces that scheme for correctness.

Happy to coordinate / rebase if #58's registry approach is preferred instead.