### PR TITLE
Add working track cover art for Traktor catalog responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ cert/keystore.*
 cert/server.*
 
 .idea
+# runtime cache: YouTube 10-char Traktor id prefix -> 11-char video id
+youtube-id-prefix-cache.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     implementation("com.github.0xf4b1:tidal-kt:v0.3.1")
 
     testImplementation(kotlin("test"))
+    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
     implementation(kotlin("stdlib-jdk8"))
 }
 

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -11,6 +11,11 @@ import io.ktor.server.engine.*
 import io.ktor.server.engine.sslConnector
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.calllogging.*
+import io.ktor.server.request.httpMethod
+import io.ktor.server.request.path
+import io.ktor.server.request.queryString
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.*
 import org.apache.log4j.BasicConfigurator
 import sources.ISource
@@ -20,6 +25,9 @@ import sources.Youtube
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URI
 import java.security.KeyStore
 import java.util.*
 import kotlin.collections.ArrayList
@@ -28,6 +36,12 @@ import kotlin.math.min
 val sources: ArrayList<ISource> = ArrayList()
 val trackIdToSource: HashMap<String, Int> = HashMap()
 val traktorIdToTrackId: HashMap<Long, String> = HashMap()
+internal val traktorIdToTrackResponse: HashMap<Long, TrackResponse> = HashMap()
+internal val traktorIdToCoverOrigin: HashMap<Long, String> = HashMap()
+
+private const val COVER_CACHE_MAX = 256
+private const val COVER_CACHE_MAX_BYTES = 16 * 1024 * 1024
+private var lastDownloadData = ByteArray(0)
 
 val allSources = mapOf(
     "youtube" to Youtube::class.java,
@@ -61,6 +75,146 @@ fun register(source: Class<out ISource>) {
     }
 }
 
+/**
+ * Traktor loads artwork from [Image.uri] / [Image.dynamic_uri]. Point both at our HTTPS host
+ * (`api.beatport.com` via /etc/hosts) so fetches go through this proxy.
+ *
+ * When [hasArt] is false, returns null so JSON omits image fields (`explicitNulls = false`).
+ */
+internal fun proxiedCoverImage(traktorId: Long, hasArt: Boolean): Image? {
+    if (!hasArt) return null
+    val uri = coverProxyUrl(traktorId)
+    return Image(id = traktorId, uri = uri, dynamic_uri = uri)
+}
+
+internal fun coverProxyUrl(traktorId: Long): String =
+    "https://api.beatport.com/v4/catalog/tracks/$traktorId/cover/"
+
+internal fun parseCatalogTrackIds(params: Parameters): List<Long> {
+    val fromId = params.getAll("id").orEmpty()
+    val fromIds = params.getAll("ids").orEmpty()
+    return (fromId + fromIds)
+        .flatMap { value -> value.split(',', ' ', '\t') }
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .mapNotNull { it.toLongOrNull() }
+        .distinct()
+}
+
+/**
+ * Allow only remote HTTPS cover origins. Blocks cleartext and common local/private targets
+ * to reduce SSRF risk when proxying artwork.
+ */
+internal fun isAllowedCoverOriginUrl(url: String): Boolean {
+    val uri = try {
+        URI(url.trim())
+    } catch (_: Exception) {
+        return false
+    }
+    if (!uri.scheme.equals("https", ignoreCase = true)) return false
+    if (!uri.userInfo.isNullOrEmpty()) return false
+    val host = uri.host?.lowercase()?.trim('.') ?: return false
+    if (host.isEmpty()) return false
+    if (host == "localhost" || host.endsWith(".localhost") || host.endsWith(".local")) {
+        return false
+    }
+    return !isPrivateOrLocalHost(host)
+}
+
+internal fun isPrivateOrLocalHost(host: String): Boolean {
+    if (host == "::1" || host == "0:0:0:0:0:0:0:1") return true
+    val ipv4 = host.split('.')
+    if (ipv4.size == 4 && ipv4.all { part -> part.toIntOrNull()?.let { it in 0..255 } == true }) {
+        val a = ipv4[0].toInt()
+        val b = ipv4[1].toInt()
+        return when {
+            a == 0 -> true
+            a == 10 -> true
+            a == 127 -> true
+            a == 169 && b == 254 -> true
+            a == 172 && b in 16..31 -> true
+            a == 192 && b == 168 -> true
+            else -> false
+        }
+    }
+    if (host.contains(':')) {
+        return host.startsWith("fc") ||
+            host.startsWith("fd") ||
+            host.startsWith("fe80") ||
+            host.startsWith("::ffff:127.") ||
+            host.startsWith("::ffff:10.") ||
+            host.startsWith("::ffff:192.168.")
+    }
+    return false
+}
+
+internal data class CoverDownload(val bytes: ByteArray, val contentType: ContentType)
+
+/**
+ * LRU cache of cover bytes keyed by upstream origin URL.
+ */
+internal class CoverCache(
+    private val maxSize: Int = COVER_CACHE_MAX,
+    private val maxBytes: Long = COVER_CACHE_MAX_BYTES.toLong()
+) {
+    private val lock = Any()
+    private var totalBytes = 0L
+    private val map = LinkedHashMap<String, CoverDownload>(maxSize, 0.75f, true)
+
+    init {
+        require(maxSize > 0) { "maxSize must be positive" }
+        require(maxBytes > 0) { "maxBytes must be positive" }
+    }
+
+    fun put(originUrl: String, cover: CoverDownload) {
+        synchronized(lock) {
+            val stored = CoverDownload(cover.bytes.copyOf(), cover.contentType)
+            val previous = map.put(originUrl, stored)
+            totalBytes += stored.bytes.size
+            if (previous != null) {
+                totalBytes -= previous.bytes.size
+            }
+            trimToLimits()
+        }
+    }
+
+    fun get(originUrl: String): CoverDownload? {
+        synchronized(lock) {
+            val hit = map[originUrl] ?: return null
+            return CoverDownload(hit.bytes.copyOf(), hit.contentType)
+        }
+    }
+
+    fun size(): Int = synchronized(lock) { map.size }
+
+    fun byteSize(): Long = synchronized(lock) { totalBytes }
+
+    private fun trimToLimits() {
+        val iterator = map.entries.iterator()
+        while (
+            (map.size > maxSize || totalBytes > maxBytes) &&
+            map.size > 1 &&
+            iterator.hasNext()
+        ) {
+            val eldest = iterator.next()
+            totalBytes -= eldest.value.bytes.size
+            iterator.remove()
+        }
+    }
+}
+
+internal val coverCache = CoverCache()
+
+/** Overridable for tests; production uses [downloadCover]. */
+internal var coverDownloader: (String) -> CoverDownload = ::downloadCover
+
+internal fun getCachedOrDownloadCover(origin: String): CoverDownload {
+    coverCache.get(origin)?.let { return it }
+    val cover = coverDownloader(origin)
+    coverCache.put(origin, cover)
+    return cover
+}
+
 fun processTracks(id: Int, tracks: List<Track>): List<TrackResponse> {
     return tracks.map { track ->
         trackIdToSource[track.id] = id
@@ -68,8 +222,156 @@ fun processTracks(id: Int, tracks: List<Track>): List<TrackResponse> {
         if (!traktorIdToTrackId.containsKey(traktorId)) {
             traktorIdToTrackId[traktorId] = if (track.id.length > 10) track.id.substring(10) else ""
         }
-        TrackResponse(traktorId, track.artists, track.name, track.length_ms)
+        val rawOrigin = track.release.image?.uri?.takeIf { it.isNotBlank() }
+            ?: track.release.image?.dynamic_uri?.takeIf { it.isNotBlank() }
+        val origin = rawOrigin?.takeIf { isAllowedCoverOriginUrl(it) }
+        if (origin != null) {
+            traktorIdToCoverOrigin[traktorId] = origin
+        } else {
+            traktorIdToCoverOrigin.remove(traktorId)
+        }
+        val image = proxiedCoverImage(traktorId, origin != null)
+        val release = if (origin != null) {
+            val labelBase = track.release.label ?: Label(name = track.release.name)
+            track.release.copy(image = image, label = labelBase.copy(image = image))
+        } else {
+            track.release.copy(image = null, label = track.release.label?.copy(image = null))
+        }
+        TrackResponse(traktorId, track.artists, track.name, track.length_ms, release, image).also {
+            traktorIdToTrackResponse[traktorId] = it
+        }
     }
+}
+
+/** Reconstruct native track id from Traktor id using the upstream prefix+suffix maps. */
+internal fun resolveFullTrackId(traktorId: Long): String? {
+    val prefix = try {
+        Utils.decode(traktorId)
+    } catch (_: Exception) {
+        return null
+    }
+    if (prefix.isBlank()) return null
+    val suffix = traktorIdToTrackId[traktorId]
+    return if (suffix != null) prefix + suffix else prefix
+}
+
+internal fun getCoverOriginUrl(traktorId: Long): String? = traktorIdToCoverOrigin[traktorId]
+
+internal fun getStoredTrack(traktorId: Long): TrackResponse? = traktorIdToTrackResponse[traktorId]
+
+/** Test helper: drop in-memory mapping for a Traktor id. */
+internal fun clearTrackMapping(traktorId: Long) {
+    val fullId = resolveFullTrackId(traktorId)
+    traktorIdToTrackId.remove(traktorId)
+    traktorIdToTrackResponse.remove(traktorId)
+    traktorIdToCoverOrigin.remove(traktorId)
+    if (fullId != null) {
+        trackIdToSource.remove(fullId)
+    }
+}
+
+/**
+ * Ask enabled sources for a track by native id. Returns the first hit as (sourceIndex, track).
+ *
+ * [trackId] may be a truncated Traktor decode (≤10 chars). YouTube [Youtube.lookupTrack]
+ * only accepts full ids or cached prefixes (no blind network expand).
+ */
+internal fun resolveTrackFromSources(trackId: String): Pair<Int, Track>? {
+    if (trackId.isBlank()) return null
+    sources.forEachIndexed { index, source ->
+        val track = try {
+            source.lookupTrack(trackId)
+        } catch (ex: Exception) {
+            println("lookupTrack failed for $trackId on ${source.name}: ${ex.message}")
+            null
+        }
+        if (track != null) {
+            return index to track
+        }
+    }
+    return null
+}
+
+/**
+ * Return a catalog [TrackResponse] for [traktorId], hydrating from sources when the in-memory
+ * mapping is missing or has no cover origin.
+ */
+internal fun ensureCatalogTrack(traktorId: Long): TrackResponse? {
+    val existing = traktorIdToTrackResponse[traktorId]
+    if (existing != null && traktorIdToCoverOrigin[traktorId] != null) {
+        return existing
+    }
+    val rawId = resolveFullTrackId(traktorId)
+    if (rawId.isNullOrBlank()) {
+        return existing
+    }
+
+    val preferredSource = trackIdToSource[rawId]
+    val fromPreferred = preferredSource?.let { sourceId ->
+        sources.getOrNull(sourceId)?.let { source ->
+            try {
+                source.lookupTrack(rawId)?.let { sourceId to it }
+            } catch (ex: Exception) {
+                println("lookupTrack failed for $rawId on ${source.name}: ${ex.message}")
+                null
+            }
+        }
+    }
+    val resolved = fromPreferred ?: resolveTrackFromSources(rawId) ?: return existing
+    val merged = mergeCatalogLookup(existing, resolved.second)
+    return processTracks(resolved.first, listOf(merged)).firstOrNull() ?: existing
+}
+
+/**
+ * When refreshing a known track (e.g. YouTube extractor fallback with name=id / duration=0),
+ * keep existing title/artists/duration and only adopt cover (and better fields) from [lookedUp].
+ */
+internal fun mergeCatalogLookup(existing: TrackResponse?, lookedUp: Track): Track {
+    if (existing == null) return lookedUp
+
+    val lookupNameIsPlaceholder =
+        lookedUp.name.isBlank() || lookedUp.name == lookedUp.id
+    val name = when {
+        existing.name.isNotBlank() && lookupNameIsPlaceholder -> existing.name
+        lookedUp.name.isNotBlank() && !lookupNameIsPlaceholder -> lookedUp.name
+        existing.name.isNotBlank() -> existing.name
+        else -> lookedUp.name
+    }
+    val lengthMs = when {
+        existing.length_ms > 0L && lookedUp.length_ms <= 0L -> existing.length_ms
+        lookedUp.length_ms > 0L -> lookedUp.length_ms
+        else -> existing.length_ms
+    }
+    val lookupArtistIsPlaceholder = lookedUp.artists.isEmpty() ||
+        lookedUp.artists.all { it.name.isBlank() || it.name.equals("YouTube", ignoreCase = true) }
+    val artists = when {
+        existing.artists.isNotEmpty() && lookupArtistIsPlaceholder -> existing.artists
+        lookedUp.artists.isNotEmpty() -> lookedUp.artists
+        else -> existing.artists
+    }
+
+    val releaseName = existing.release?.name.orEmpty()
+        .ifBlank { lookedUp.release.name }
+        .ifBlank { name }
+    val lookupCover = lookedUp.release.image?.uri?.takeIf { it.isNotBlank() }
+        ?: lookedUp.release.image?.dynamic_uri?.takeIf { it.isNotBlank() }
+    val release = if (lookupCover != null) {
+        releaseWithArt(
+            releaseName,
+            lookupCover,
+            lookedUp.release.image?.dynamic_uri?.takeIf { it.isNotBlank() }
+        )
+    } else {
+        existing.release ?: lookedUp.release
+    }
+
+    return Track(
+        id = lookedUp.id.ifBlank { resolveFullTrackId(existing.id) ?: existing.id.toString() },
+        artists = artists,
+        name = name,
+        length_ms = lengthMs,
+        release = release
+    )
 }
 
 /**
@@ -116,7 +418,7 @@ fun main() {
     val alias = "foo"
     var serverConfiguration: NettyApplicationEngine.Configuration.() -> Unit
 
-    if(prop.getProperty("server.useKeystore", "false").toBoolean()) {
+    if (prop.getProperty("server.useKeystore", "false").toBoolean()) {
         val keystorePassword = "changeit"
 
         val keyStore = KeyStore.getInstance("JKS").apply {
@@ -147,140 +449,334 @@ fun main() {
         }
     }
 
-    embeddedServer(Netty, applicationEnvironment(), serverConfiguration, module = {
-        install(CallLogging)
-        install(ContentNegotiation) {
-            json(Json {
-                prettyPrint = true
-                isLenient = true
-            })
+    embeddedServer(Netty, applicationEnvironment(), serverConfiguration, module = Application::module)
+        .start(wait = true)
+}
+
+/**
+ * Shared JSON settings for Beatport-shaped API responses.
+ *
+ * - [encodeDefaults] = true: do not globally drop default-valued fields (safer for Traktor).
+ * - [explicitNulls] = false: omit nullable art fields (`image` / `release.image`) when absent.
+ */
+internal val apiJson = Json {
+    prettyPrint = true
+    isLenient = true
+    encodeDefaults = true
+    explicitNulls = false
+}
+
+/**
+ * Ktor application module (shared by the HTTPS server and [io.ktor.server.testing.testApplication]).
+ */
+fun Application.module() {
+    install(CallLogging) {
+        format { call ->
+            val status = call.response.status()
+            val method = call.request.httpMethod.value
+            val path = call.request.path()
+            val query = call.request.queryString()
+            val uri = if (query.isEmpty()) path else "$path?$query"
+            val statusText = status?.toString() ?: "Unhandled"
+            "$statusText: $method - $uri"
         }
-        var data = ByteArray(0)
-        routing {
+    }
+    install(ContentNegotiation) {
+        json(apiJson)
+    }
+    routing {
 
-            get("/v4/auth/o/authorize/") {
-                call.respondRedirect("traktor://bp_oauth?code=foo")
+        get("/v4/auth/o/authorize/") {
+            call.respondRedirect("traktor://bp_oauth?code=foo")
+        }
+
+        post("/v4/auth/o/token/") {
+            call.respond(Auth("foo", 36000, "Bearer", "app:locker user:dj", "bar"))
+        }
+
+        get("/v4/auth/logout/") {
+            call.respond(HttpStatusCode.OK)
+        }
+
+        get("/v4/my/account/") {
+            call.respond(Account(prop.getProperty("beatport.accountId").toInt()))
+        }
+
+        get("/v4/my/license/") {
+            val licenseName = prop.getProperty("beatport.license", "macos")
+            val licenseFile = Config::class.java.getResource("licenses/${licenseName}.json")
+
+            if (licenseFile == null) {
+                call.respond(HttpStatusCode.InternalServerError, "License file '${licenseName}' not found")
+            } else {
+                call.respondBytes(licenseFile.readBytes())
             }
+        }
 
-            post("/v4/auth/o/token/") {
-                call.respond(Auth("foo", 36000, "Bearer", "app:locker user:dj", "bar"))
+        get("/v4/catalog/search") {
+            val q = call.parameters["q"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+            val results = executeSearch(q, call.parameters.contains("more"))
+            val nextUrl = if (results.isNotEmpty()) "api.beatport.com/v4/catalog/search?q=$q&more" else ""
+            call.respond(QueryTrackResponse(results, nextUrl))
+        }
+
+        get("/search/v1/tracks") {
+            val q = call.parameters["q"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+            val results = executeSearch(q, call.parameters.contains("more"))
+            call.respond(BeatportSearchResponse(results.toNewSearchApi()))
+        }
+
+        get("/v4/catalog/genres") {
+            call.respondRedirect("/v4/catalog/genres/")
+        }
+
+        get("/v4/catalog/genres/") {
+            call.respond(Genres(sources.mapIndexed { id, source -> Genre(id + 1, source.name) }))
+        }
+
+        get("/v4/catalog/genres/{id}/tracks/") {
+            call.parameters["id"]?.let {
+                call.respond(
+                    GenreTrackResponse(
+                        processTracks(it.toInt() - 1, sources[it.toInt() - 1].getGenre()),
+                        "" /* unused by Traktor */
+                    )
+                )
             }
+        }
 
-            get("/v4/auth/logout/") {
-                call.respond(HttpStatusCode.OK)
+        get("/v4/curation/playlists/") {
+            call.parameters["genre_id"]?.let {
+                val results = sources[it.toInt() - 1].getCuratedPlaylists(!call.parameters.contains("more")).map { playlist ->
+                    Playlist((it + playlist.id).toLong(), playlist.name)
+                }
+                call.respond(
+                    CuratedPlaylistsResponse(
+                        results,
+                        if (results.isNotEmpty()) "api.beatport.com/v4/curation/playlists/?genre_id=$it&more" else ""
+                    )
+                )
             }
+        }
 
-            get("/v4/my/account/") {
-                call.respond(Account(prop.getProperty("beatport.accountId").toInt()))
+        get("/v4/curation/playlists/{id}/tracks/") {
+            call.parameters["id"]?.let {
+                val sourceId = it.substring(0, 1).toInt() - 1
+                val results = processTracks(sourceId, sources[sourceId].getCuratedPlaylist(it.substring(1)))
+                call.respond(
+                    CuratedPlaylistResponse(
+                        results.map { track -> PlaylistItem(track) },
+                        "" /* unused by Traktor */
+                    )
+                )
             }
+        }
 
-            get("/v4/my/license/") {
-                val licenseName = prop.getProperty("beatport.license", "macos")
-                val licenseFile = Config::class.java.getResource("licenses/${licenseName}.json")
+        get("/v4/my/playlists/") {
+            call.respond(
+                CuratedPlaylistsResponse(
+                    sources.mapIndexed { id, source ->
+                        source.getPlaylists().map { playlist ->
+                            Playlist("${id + 1}${playlist.id}".toLong(), playlist.name)
+                        }
+                    }.flatten(),
+                    "" /* not needed */
+                )
+            )
+        }
 
-                if (licenseFile == null) {
-                    call.respond(HttpStatusCode.InternalServerError, "License file '${licenseName}' not found")
+        get("/v4/my/playlists/{id}/tracks/") {
+            call.parameters["id"]?.let {
+                val sourceId = it.substring(0, 1).toInt() - 1
+                val results = processTracks(sourceId, sources[sourceId].getPlaylist(it.substring(1)))
+                call.respond(
+                    CuratedPlaylistResponse(
+                        results.map { track -> PlaylistItem(track) },
+                        "" /* unused by Traktor */
+                    )
+                )
+            }
+        }
+
+        get("/v4/catalog/genres/{id}/top/100/") {
+            call.parameters["id"]?.let {
+                call.respond(
+                    GenreTrackResponse(
+                        processTracks(it.toInt() - 1, sources[it.toInt() - 1].getTop100()),
+                        "" /* unused by Traktor */
+                    )
+                )
+            }
+        }
+
+        get("/v4/catalog/tracks/") {
+            val ids = parseCatalogTrackIds(call.request.queryParameters)
+            if (ids.isEmpty()) {
+                call.respond(GenreTrackResponse(emptyList(), ""))
+                return@get
+            }
+            val results = withContext(Dispatchers.IO) {
+                ids.mapNotNull { ensureCatalogTrack(it) }
+            }
+            call.respond(GenreTrackResponse(results, ""))
+        }
+
+        get("/v4/catalog/tracks/{id}/") {
+            call.parameters["id"]?.let { id ->
+                val traktorId = id.toLongOrNull()
+                    ?: return@let call.respond(HttpStatusCode.BadRequest)
+                val track = withContext(Dispatchers.IO) { ensureCatalogTrack(traktorId) }
+                if (track != null) {
+                    call.respond(track)
                 } else {
-                    call.respondBytes(licenseFile.readBytes())
+                    call.respond(HttpStatusCode.NotFound)
                 }
-            }
-
-            get("/v4/catalog/search") {
-                val q = call.parameters["q"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-                val results = executeSearch(q, call.parameters.contains("more"))
-                val nextUrl = if (results.isNotEmpty()) "api.beatport.com/v4/catalog/search?q=$q&more" else ""
-                call.respond(QueryTrackResponse(results, nextUrl))
-            }
-
-            get("/search/v1/tracks") {
-                val q = call.parameters["q"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-                val results = executeSearch(q, call.parameters.contains("more"))
-                call.respond(BeatportSearchResponse(results.toNewSearchApi()))
-            }
-
-            get("/v4/catalog/genres") {
-                call.respondRedirect("/v4/catalog/genres/")
-            }
-
-            get("/v4/catalog/genres/") {
-                call.respond(Genres(sources.mapIndexed { id, source -> Genre(id + 1, source.name) }))
-            }
-
-            get("/v4/catalog/genres/{id}/tracks/") {
-                call.parameters["id"]?.let {
-                    call.respond(GenreTrackResponse(processTracks(it.toInt() - 1, sources[it.toInt() - 1].getGenre()), "" /* unused by Traktor */))
-                }
-            }
-
-            get("/v4/curation/playlists/") {
-                call.parameters["genre_id"]?.let {
-                    val results = sources[it.toInt() - 1].getCuratedPlaylists(!call.parameters.contains("more")).map { playlist ->
-                        Playlist((it + playlist.id).toLong(), playlist.name)
-                    }
-                    call.respond(CuratedPlaylistsResponse(results, if (results.isNotEmpty()) "api.beatport.com/v4/curation/playlists/?genre_id=$it&more" else ""))
-                }
-            }
-
-            get("/v4/curation/playlists/{id}/tracks/") {
-                call.parameters["id"]?.let {
-                    val sourceId = it.substring(0, 1).toInt() - 1
-                    val results = processTracks(sourceId, sources[sourceId].getCuratedPlaylist(it.substring(1)))
-                    call.respond(CuratedPlaylistResponse(results.map { track -> PlaylistItem(track) }, "" /* unused by Traktor */))
-                }
-            }
-
-            get("/v4/my/playlists/") {
-                call.respond(CuratedPlaylistsResponse(sources.mapIndexed { id, source -> source.getPlaylists().map { playlist -> Playlist("${id + 1}${playlist.id}".toLong(), playlist.name) } }.flatten(), "" /* not needed */))
-            }
-
-            get("/v4/my/playlists/{id}/tracks/") {
-                call.parameters["id"]?.let {
-                    val sourceId = it.substring(0, 1).toInt() - 1
-                    val results = processTracks(sourceId, sources[sourceId].getPlaylist(it.substring(1)))
-                    call.respond(CuratedPlaylistResponse(results.map { track -> PlaylistItem(track) }, "" /* unused by Traktor */))
-                }
-            }
-
-            get("/v4/catalog/genres/{id}/top/100/") {
-                call.parameters["id"]?.let {
-                    call.respond(GenreTrackResponse(processTracks(it.toInt() - 1, sources[it.toInt() - 1].getTop100()), "" /* unused by Traktor */))
-                }
-            }
-
-            get("/v4/catalog/tracks/{id}/download/") {
-                call.parameters["id"]?.let {
-                    val trackId = Utils.decode(it.toLong()) + traktorIdToTrackId[it.toLong()]!!
-                    data = sources[trackIdToSource[trackId]!!].download(trackId)
-                    call.respond(Download("https://api.beatport.com/output.mp4", "foo", 1337))
-                }
-            }
-
-            // Serve the last downloaded track
-            head("/output.mp4") {
-                call.response.header("content-type", "video/mp4")
-                call.respondBytes(data)
-            }
-
-            get("/output.mp4") {
-                call.response.header("content-type", "video/mp4")
-                call.respondBytes(data)
             }
         }
-    }).start(wait = true)
+
+        get("/v4/catalog/tracks/{id}/cover/") {
+            val traktorId = call.parameters["id"]?.toLongOrNull()
+                ?: return@get call.respond(HttpStatusCode.BadRequest)
+            val origin = withContext(Dispatchers.IO) {
+                ensureCatalogTrack(traktorId)
+                getCoverOriginUrl(traktorId)
+            } ?: return@get call.respond(HttpStatusCode.NotFound)
+            val cover = try {
+                withContext(Dispatchers.IO) { getCachedOrDownloadCover(origin) }
+            } catch (ex: Exception) {
+                println("Cover fetch failed for $traktorId ($origin): ${ex.message}")
+                return@get call.respond(HttpStatusCode.BadGateway)
+            }
+            call.respondBytes(cover.bytes, cover.contentType)
+        }
+
+        get("/v4/catalog/tracks/{id}/download/") {
+            call.parameters["id"]?.let {
+                val traktorId = it.toLongOrNull()
+                    ?: return@let call.respond(HttpStatusCode.BadRequest)
+                withContext(Dispatchers.IO) { ensureCatalogTrack(traktorId) }
+                val trackId = resolveFullTrackId(traktorId)
+                    ?: return@let call.respond(HttpStatusCode.NotFound)
+                val sourceId = trackIdToSource[trackId]
+                    ?: return@let call.respond(HttpStatusCode.NotFound)
+                lastDownloadData = withContext(Dispatchers.IO) {
+                    sources[sourceId].download(trackId)
+                }
+                val lengthMs = getStoredTrack(traktorId)?.length_ms
+                    ?.coerceIn(0L, Int.MAX_VALUE.toLong())
+                    ?.toInt()
+                    ?: 1337
+                call.respond(Download("https://api.beatport.com/output.mp4", "foo", lengthMs))
+            }
+        }
+
+        // Serve the last downloaded track
+        head("/output.mp4") {
+            call.response.header("content-type", "video/mp4")
+            call.respondBytes(lastDownloadData)
+        }
+
+        get("/output.mp4") {
+            call.response.header("content-type", "video/mp4")
+            call.respondBytes(lastDownloadData)
+        }
+    }
 }
 
 private fun List<TrackResponse>.toNewSearchApi(): List<BeatportTrack> {
     return this.map {
         BeatportTrack(
-            artists = it.artists.map {
+            artists = it.artists.map { artist ->
                 BeatportArtist(
-                    it.name,
+                    artist.name,
                     "Artist" // Required by traktor
                 )
             },
             track_name = it.name,
             track_id = it.id,
-            length = it.length_ms
+            length = it.length_ms,
+            release = it.release,
+            image = it.image
         )
+    }
+}
+
+private const val COVER_MAX_REDIRECTS = 5
+
+/**
+ * Resolve a redirect [Location] against [currentUrl] and accept it only when the result
+ * still passes [isAllowedCoverOriginUrl].
+ */
+internal fun resolveCoverRedirectUrl(currentUrl: String, location: String): String? {
+    val resolved = try {
+        URI(currentUrl).resolve(location.trim()).normalize().toString()
+    } catch (_: Exception) {
+        return null
+    }
+    return resolved.takeIf { isAllowedCoverOriginUrl(it) }
+}
+
+internal fun downloadCover(url: String): CoverDownload {
+    var current = url.trim()
+    if (!isAllowedCoverOriginUrl(current)) {
+        throw IOException("Cover URL not allowed: $current")
+    }
+    repeat(COVER_MAX_REDIRECTS + 1) { hop ->
+        val con = URI.create(current).toURL().openConnection() as HttpURLConnection
+        con.connectTimeout = 10_000
+        con.readTimeout = 15_000
+        con.instanceFollowRedirects = false
+        con.setRequestProperty("User-Agent", "traktor-streaming-proxy/cover")
+        val code = try {
+            con.responseCode
+        } catch (ex: Exception) {
+            con.disconnect()
+            throw ex
+        }
+        when {
+            code in 200..299 -> {
+                try {
+                    val bytes = con.inputStream.use { it.readBytes() }
+                    if (bytes.isEmpty()) {
+                        throw IOException("Empty cover body from $current")
+                    }
+                    return CoverDownload(bytes, contentType = coverContentType(con.contentType))
+                } finally {
+                    con.disconnect()
+                }
+            }
+            code in 300..399 -> {
+                val location = con.getHeaderField("Location")
+                con.errorStream?.close()
+                con.disconnect()
+                if (hop >= COVER_MAX_REDIRECTS) {
+                    throw IOException("Too many redirects fetching cover from $url")
+                }
+                if (location.isNullOrBlank()) {
+                    throw IOException("Cover redirect missing Location from $current (HTTP $code)")
+                }
+                current = resolveCoverRedirectUrl(current, location)
+                    ?: throw IOException("Cover redirect not allowed: $location (from $current)")
+            }
+            else -> {
+                con.errorStream?.close()
+                con.disconnect()
+                throw IOException("Cover download failed HTTP $code from $current")
+            }
+        }
+    }
+    throw IOException("Cover download failed from $url")
+}
+
+internal fun coverContentType(raw: String?): ContentType {
+    val mime = raw?.substringBefore(';')?.trim()?.lowercase().orEmpty()
+    return when {
+        mime.isEmpty() || mime == "image/jpg" -> ContentType.Image.JPEG
+        mime.startsWith("image/") -> try {
+            ContentType.parse(mime)
+        } catch (_: Exception) {
+            ContentType.Image.JPEG
+        }
+        else -> ContentType.Image.JPEG
     }
 }

--- a/src/main/kotlin/beatport/api/Data.kt
+++ b/src/main/kotlin/beatport/api/Data.kt
@@ -22,10 +22,74 @@ data class Genres(val results: List<Genre>)
 @Serializable
 data class Artist(val id: Int, val name: String)
 
-data class Track(val id: String, val artists: List<Artist>, val name: String, val length_ms: Long)
+/**
+ * Beatport-shaped artwork object. Traktor reads [uri] / [dynamic_uri] from catalog track payloads.
+ * [dynamic_uri] may contain `{w}` / `{h}` placeholders (Beatport convention).
+ */
+@Serializable
+data class Image(
+    val id: Long = 0,
+    val uri: String = "",
+    val dynamic_uri: String = ""
+)
 
 @Serializable
-data class TrackResponse(val id: Long, val artists: List<Artist>, val name: String, val length_ms: Long)
+data class Label(
+    val id: Long = 0,
+    val name: String = "",
+    /** Null when there is no artwork (omitted in JSON via explicitNulls = false). */
+    val image: Image? = null
+)
+
+@Serializable
+data class Release(
+    val id: Long = 0,
+    val name: String = "",
+    /** Null when there is no artwork (omitted in JSON via explicitNulls = false). */
+    val image: Image? = null,
+    val label: Label? = null
+)
+
+/**
+ * Build a minimal Beatport [Release] that carries cover art for Traktor.
+ * When [imageUrl] is blank, returns a release with name only (no image fields).
+ */
+fun releaseWithArt(
+    releaseName: String,
+    imageUrl: String?,
+    dynamicUri: String? = null
+): Release {
+    val uri = imageUrl?.trim().orEmpty()
+    if (uri.isEmpty()) {
+        return Release(name = releaseName)
+    }
+    val dynamic = dynamicUri?.trim()?.takeIf { it.isNotEmpty() } ?: uri
+    val image = Image(uri = uri, dynamic_uri = dynamic)
+    return Release(
+        name = releaseName,
+        image = image,
+        label = Label(name = releaseName, image = image)
+    )
+}
+
+data class Track(
+    val id: String,
+    val artists: List<Artist>,
+    val name: String,
+    val length_ms: Long,
+    val release: Release = Release()
+)
+
+@Serializable
+data class TrackResponse(
+    val id: Long,
+    val artists: List<Artist>,
+    val name: String,
+    val length_ms: Long,
+    val release: Release? = null,
+    /** Top-level image (real Beatport includes this alongside [release].image). Null = no art. */
+    val image: Image? = null
+)
 
 @Serializable
 data class GenreTrackResponse(val results: List<TrackResponse>, val next: String)
@@ -61,6 +125,8 @@ data class BeatportTrack(
     val artists: List<BeatportArtist>,
     val track_name: String,
     val length: Long,
+    val release: Release? = null,
+    val image: Image? = null
 )
 
 @Serializable

--- a/src/main/kotlin/sources/ISource.kt
+++ b/src/main/kotlin/sources/ISource.kt
@@ -45,6 +45,12 @@ interface ISource {
     fun query(query: String, reset: Boolean): List<Track>
 
     /**
+     * Resolve a single track by source-native id (for lazy catalog/cover hydration).
+     * Default: unsupported.
+     */
+    fun lookupTrack(id: String): Track? = null
+
+    /**
      * Download music track data (must be in mp4 format)
      */
     fun download(id: String): ByteArray

--- a/src/main/kotlin/sources/Spotify.kt
+++ b/src/main/kotlin/sources/Spotify.kt
@@ -98,7 +98,15 @@ class Spotify : ISource {
     }
 
     private fun mapTracks(tracks: List<io.github.tiefensuche.spotify.api.Track>): List<Track> {
-        return tracks.filter { it.playable }.map { track -> Track(track.id.substring(track.id.lastIndexOf(':') + 1), listOf(Artist(1, track.artist)), track.title, track.duration) }
+        return tracks.filter { it.playable }.map { track ->
+            Track(
+                track.id.substring(track.id.lastIndexOf(':') + 1),
+                listOf(Artist(1, track.artist)),
+                track.title,
+                track.duration,
+                beatport.api.releaseWithArt(track.album.ifBlank { track.title }, track.artwork)
+            )
+        }
     }
 
     private fun mapPlaylists(playlists: List<io.github.tiefensuche.spotify.api.Playlist>): List<Playlist> {

--- a/src/main/kotlin/sources/Tidal.kt
+++ b/src/main/kotlin/sources/Tidal.kt
@@ -4,6 +4,7 @@ import Config.prop
 import beatport.api.Artist
 import beatport.api.Playlist
 import beatport.api.Track
+import beatport.api.releaseWithArt
 import com.tiefensuche.tidal.api.TidalApi
 import org.xml.sax.Attributes
 import org.xml.sax.InputSource
@@ -44,7 +45,7 @@ class Tidal : ISource {
             val next = api.getTracks(false)
             res.addAll(next)
         } while (next.isNotEmpty())
-        return res.map { Track(it.id.toString(), listOf(Artist(1, it.artist)), it.title, it.duration) }
+        return res.map { mapTrack(it) }
     }
 
     override fun getCuratedPlaylists(reset: Boolean): List<Playlist> {
@@ -79,7 +80,7 @@ class Tidal : ISource {
                     res
                 }
                 PlaylistType.MIX -> api.getMix(it.first, true)
-            }.map { Track(it.id.toString(), listOf(Artist(1, it.artist)), it.title, it.duration) }
+            }.map { mapTrack(it) }
         }
     }
 
@@ -89,20 +90,29 @@ class Tidal : ISource {
             val next = api.getArtist(artists[id.toInt()].id, false)
             res.addAll(next)
         } while (next.isNotEmpty())
-        return res.map { Track(it.id.toString(), listOf(Artist(1, it.artist)), it.title, it.duration) }
+        return res.map { mapTrack(it) }
     }
 
     override fun getTop100(): List<Track> {
         api.getMixes().forEach {
             if (it.title == "My New Arrivals")
-                return api.getMix(it.uuid, false).map { Track(it.id.toString(), listOf(Artist(1, it.artist)), it.title, it.duration) }
+                return api.getMix(it.uuid, false).map { mapTrack(it) }
         }
         return emptyList()
     }
 
     override fun query(query: String, reset: Boolean): List<Track> {
-        return api.query(query, reset)
-            .map { Track(it.id.toString(), listOf(Artist(1, it.artist)), it.title, it.duration) }
+        return api.query(query, reset).map { mapTrack(it) }
+    }
+
+    private fun mapTrack(track: com.tiefensuche.tidal.api.Track): Track {
+        return Track(
+            track.id.toString(),
+            listOf(Artist(1, track.artist)),
+            track.title,
+            track.duration,
+            releaseWithArt(track.title, track.artwork)
+        )
     }
 
     override fun download(id: String): ByteArray {

--- a/src/main/kotlin/sources/Youtube.kt
+++ b/src/main/kotlin/sources/Youtube.kt
@@ -7,8 +7,18 @@ import org.schabi.newpipe.extractor.downloader.Response
 import org.schabi.newpipe.extractor.localization.Localization
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.MUSIC_SONGS
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import java.io.File
+import java.net.HttpURLConnection
 import java.net.URL
+import java.net.URI
 import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutorCompletionService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
 
 class Youtube : ISource {
 
@@ -63,6 +73,44 @@ class Youtube : ISource {
         return downloadTrack(getAudioStream(id))
     }
 
+    /**
+     * Hydrate metadata + thumbnail for a YouTube video id.
+     *
+     * Accepts a full 11-char id, or a 10-char prefix already present in the prefix cache
+     * (warmed when we previously saw the full id). Does **not** network-expand prefixes:
+     * Traktor decode yields ≤10 chars for every source, and Spotify/Tidal ids share the same
+     * alphabet — blind `i.ytimg` probing would mis-attribute foreign ids to YouTube.
+     */
+    override fun lookupTrack(id: String): Track? {
+        val videoId = resolveVideoIdFromPrefix(id, allowNetworkExpand = false) ?: return null
+        rememberVideoId(videoId)
+        val fallbackThumb = thumbnailUrl(videoId)
+        return try {
+            val extractor = ServiceList.YouTube.getStreamExtractor("https://www.youtube.com/watch?v=$videoId")
+            extractor.fetchPage()
+            val title = extractor.name.ifBlank { videoId }
+            val artist = extractor.uploaderName.ifBlank { "YouTube" }
+            val durationMs = extractor.length.coerceAtLeast(0L) * 1000L
+            val thumb = bestThumbnailUrl(extractor.thumbnails) ?: fallbackThumb
+            Track(
+                videoId,
+                listOf(Artist(1, artist)),
+                title,
+                durationMs,
+                releaseWithArt(title, thumb)
+            )
+        } catch (ex: Exception) {
+            println("YouTube: lookupTrack extractor failed for $videoId (${ex.message}), using i.ytimg fallback")
+            Track(
+                videoId,
+                listOf(Artist(1, "YouTube")),
+                videoId,
+                0L,
+                releaseWithArt(videoId, fallbackThumb)
+            )
+        }
+    }
+
     private fun downloadTrack(path: String): ByteArray {
         val con = URL(path).openConnection()
         con.setRequestProperty("range", "bytes=0-")
@@ -79,10 +127,306 @@ class Youtube : ISource {
         val results = LinkedList<Track>()
         for (item in items) {
             if (item is StreamInfoItem) {
-                results.add(Track(item.url.substring(item.url.indexOf('=') + 1), listOf(Artist(1, item.uploaderName)), item.name, item.duration * 1000))
+                val videoId = item.url.substring(item.url.indexOf('=') + 1)
+                // Persist prefix→full so cold catalog hydration after restart can resolve
+                // Traktor's 10-char decode without probing (avoids Spotify/Tidal collisions).
+                rememberVideoId(videoId)
+                val thumbUrl = bestThumbnailUrl(item.thumbnails) ?: thumbnailUrl(videoId)
+                results.add(
+                    Track(
+                        videoId,
+                        listOf(Artist(1, item.uploaderName)),
+                        item.name,
+                        item.duration * 1000,
+                        releaseWithArt(item.name, thumbUrl)
+                    )
+                )
             }
         }
         return results
+    }
+
+    companion object {
+        private const val MAX_CONCURRENT_PREFIX_EXPANDS = 2
+        private const val PREFIX_EXPAND_WAIT_SECONDS = 20L
+        private const val PREFIX_CACHE_FILE = "youtube-id-prefix-cache.properties"
+
+        private val YOUTUBE_ID_CHARS =
+            (('0'..'9') + ('a'..'z') + ('A'..'Z') + listOf('-', '_')).toList()
+        private val YOUTUBE_ID_CHAR_SET = YOUTUBE_ID_CHARS.toSet()
+        private val prefixCache = ConcurrentHashMap<String, String>()
+        /** Prefixes with more than one valid 11-char completion — do not guess. */
+        private val ambiguousPrefixes = ConcurrentHashMap.newKeySet<String>()
+        private val prefixInflight = ConcurrentHashMap<String, CompletableFuture<String?>>()
+        private val expandPermits = Semaphore(MAX_CONCURRENT_PREFIX_EXPANDS)
+        private val expandExecutor = Executors.newFixedThreadPool(8) { r ->
+            Thread(r, "youtube-id-expand").apply { isDaemon = true }
+        }
+        private val prefixCacheLock = Any()
+        @Volatile private var prefixCacheLoaded = false
+
+        /** Overridable for tests; production probes i.ytimg.com. */
+        internal var thumbnailProbe: (String) -> Boolean = ::probeThumbnailExists
+
+        /** When false, skip reading/writing [PREFIX_CACHE_FILE] (unit tests). */
+        internal var prefixCachePersistenceEnabled: Boolean = true
+
+        internal fun isYouTubeVideoId(id: String): Boolean =
+            id.length == 11 && id.all { it in YOUTUBE_ID_CHAR_SET }
+
+        internal fun isYouTubeVideoIdPrefix(id: String): Boolean =
+            id.length == 10 && id.all { it in YOUTUBE_ID_CHAR_SET }
+
+        /** Standard public thumbnail CDN URL (no API call). */
+        internal fun thumbnailUrl(videoId: String, quality: String = "hqdefault"): String =
+            "https://i.ytimg.com/vi/$videoId/$quality.jpg"
+
+        /**
+         * Resolve a full 11-char video id. Accepts a full id, or a 10-char prefix produced by
+         * [beatport.api.Utils.decode] after Traktor-id truncation.
+         *
+         * When [allowNetworkExpand] is false (default; used by [lookupTrack]), only a full id or
+         * an existing prefix-cache entry is accepted — no `i.ytimg` probing. Network expand is
+         * unsafe for cross-source catalog fan-out because Spotify/Tidal ids share this alphabet.
+         *
+         * When [allowNetworkExpand] is true, probes `i.ytimg.com` for the missing final character.
+         * Concurrent callers for the same prefix share one expand (single-flight). At most
+         * [MAX_CONCURRENT_PREFIX_EXPANDS] distinct prefixes expand at once. Only an unambiguous
+         * single match is cached (memory + [PREFIX_CACHE_FILE]); multiple HEAD hits → no guess.
+         */
+        internal fun resolveVideoIdFromPrefix(
+            idOrPrefix: String,
+            allowNetworkExpand: Boolean = false,
+        ): String? {
+            if (isYouTubeVideoId(idOrPrefix)) return idOrPrefix
+            if (!isYouTubeVideoIdPrefix(idOrPrefix)) return null
+            ensurePrefixCacheLoaded()
+            prefixCache[idOrPrefix]?.let { return it }
+            if (idOrPrefix in ambiguousPrefixes) return null
+            if (!allowNetworkExpand) return null
+
+            val created = CompletableFuture<String?>()
+            val existing = prefixInflight.putIfAbsent(idOrPrefix, created)
+            if (existing != null) {
+                return awaitPrefixFuture(existing)
+            }
+            try {
+                val resolved = expandPrefixWithPermit(idOrPrefix)
+                created.complete(resolved)
+                return resolved
+            } catch (ex: Exception) {
+                created.complete(null)
+                println("YouTube: expand failed for '$idOrPrefix': ${ex.message}")
+                return null
+            } finally {
+                prefixInflight.remove(idOrPrefix, created)
+            }
+        }
+
+        /**
+         * Record a known full video id so a later 10-char Traktor decode can resolve via cache
+         * without network expand (safe across Spotify/Tidal id collisions).
+         */
+        internal fun rememberVideoId(videoId: String) {
+            if (!isYouTubeVideoId(videoId)) return
+            ensurePrefixCacheLoaded()
+            val prefix = videoId.substring(0, 10)
+            if (prefix in ambiguousPrefixes) return
+            val existing = prefixCache[prefix]
+            if (existing != null && existing != videoId) {
+                prefixCache.remove(prefix)
+                ambiguousPrefixes.add(prefix)
+                println(
+                    "YouTube: conflicting full ids for prefix '$prefix' " +
+                        "('$existing' vs '$videoId'); not caching"
+                )
+                return
+            }
+            if (existing == videoId) return
+            prefixCache[prefix] = videoId
+            persistPrefixCacheEntry(prefix, videoId)
+        }
+
+        private fun awaitPrefixFuture(future: CompletableFuture<String?>): String? {
+            return try {
+                future.get(PREFIX_EXPAND_WAIT_SECONDS, TimeUnit.SECONDS)
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        private fun expandPrefixWithPermit(prefix: String): String? {
+            // Re-check after joining any in-flight waiters / before taking a permit.
+            prefixCache[prefix]?.let { return it }
+            if (prefix in ambiguousPrefixes) return null
+            if (!expandPermits.tryAcquire(PREFIX_EXPAND_WAIT_SECONDS, TimeUnit.SECONDS)) {
+                println("YouTube: timed out waiting for expand permit for '$prefix'")
+                return null
+            }
+            try {
+                prefixCache[prefix]?.let { return it }
+                if (prefix in ambiguousPrefixes) return null
+                return when (val outcome = expandPrefixUncached(prefix)) {
+                    is PrefixExpandOutcome.Unique -> {
+                        prefixCache[prefix] = outcome.videoId
+                        persistPrefixCacheEntry(prefix, outcome.videoId)
+                        println("YouTube: expanded id prefix '$prefix' -> '${outcome.videoId}'")
+                        outcome.videoId
+                    }
+                    is PrefixExpandOutcome.Ambiguous -> {
+                        ambiguousPrefixes.add(prefix)
+                        println(
+                            "YouTube: ambiguous id prefix '$prefix' " +
+                                "(${outcome.hits.size} matches: ${outcome.hits.take(5)}); not guessing"
+                        )
+                        null
+                    }
+                    PrefixExpandOutcome.None -> {
+                        println("YouTube: could not expand id prefix '$prefix'")
+                        null
+                    }
+                }
+            } finally {
+                expandPermits.release()
+            }
+        }
+
+        /**
+         * Probe all 11th-character candidates. Require a single HEAD hit; if two or more
+         * succeed, treat as ambiguous (do not pick the first completed).
+         */
+        private fun expandPrefixUncached(prefix: String): PrefixExpandOutcome {
+            val completion = ExecutorCompletionService<String?>(expandExecutor)
+            val futures = ArrayList<Future<String?>>(YOUTUBE_ID_CHARS.size)
+            for (ch in YOUTUBE_ID_CHARS) {
+                val candidate = prefix + ch
+                futures.add(completion.submit {
+                    if (thumbnailProbe(candidate)) candidate else null
+                })
+            }
+            val hits = ArrayList<String>(2)
+            try {
+                val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(12)
+                run {
+                    repeat(futures.size) {
+                        val remainingMs = TimeUnit.NANOSECONDS.toMillis(deadline - System.nanoTime())
+                        if (remainingMs <= 0) return@run
+                        val done = try {
+                            completion.poll(remainingMs, TimeUnit.MILLISECONDS)
+                        } catch (_: Exception) {
+                            null
+                        } ?: return@run
+                        val hit = try {
+                            done.get()
+                        } catch (_: Exception) {
+                            null
+                        }
+                        if (hit != null) {
+                            hits.add(hit)
+                            // Early exit once ambiguity is proven; still cancel outstanding HEADs.
+                            if (hits.size > 1) return@run
+                        }
+                    }
+                }
+            } finally {
+                futures.forEach { it.cancel(true) }
+            }
+            return when (hits.size) {
+                0 -> PrefixExpandOutcome.None
+                1 -> PrefixExpandOutcome.Unique(hits[0])
+                else -> PrefixExpandOutcome.Ambiguous(hits.toList())
+            }
+        }
+
+        private sealed class PrefixExpandOutcome {
+            data class Unique(val videoId: String) : PrefixExpandOutcome()
+            data class Ambiguous(val hits: List<String>) : PrefixExpandOutcome()
+            data object None : PrefixExpandOutcome()
+        }
+
+        internal fun probeThumbnailExists(videoId: String): Boolean {
+            return try {
+                val con = URI.create(thumbnailUrl(videoId)).toURL().openConnection() as HttpURLConnection
+                con.requestMethod = "HEAD"
+                con.connectTimeout = 3_000
+                con.readTimeout = 3_000
+                con.instanceFollowRedirects = false
+                con.setRequestProperty("User-Agent", "traktor-streaming-proxy/youtube-id")
+                con.responseCode in 200..299
+            } catch (_: Exception) {
+                false
+            }
+        }
+
+        private fun ensurePrefixCacheLoaded() {
+            if (prefixCacheLoaded) return
+            synchronized(prefixCacheLock) {
+                if (prefixCacheLoaded) return
+                if (!prefixCachePersistenceEnabled) {
+                    prefixCacheLoaded = true
+                    return
+                }
+                try {
+                    val file = File(PREFIX_CACHE_FILE)
+                    if (file.isFile) {
+                        file.forEachLine { line ->
+                            val trimmed = line.trim()
+                            if (trimmed.isEmpty() || trimmed.startsWith("#")) return@forEachLine
+                            val eq = trimmed.indexOf('=')
+                            if (eq <= 0) return@forEachLine
+                            val prefix = trimmed.substring(0, eq)
+                            val full = trimmed.substring(eq + 1)
+                            if (isYouTubeVideoIdPrefix(prefix) &&
+                                isYouTubeVideoId(full) &&
+                                full.startsWith(prefix)
+                            ) {
+                                prefixCache.putIfAbsent(prefix, full)
+                            }
+                        }
+                    }
+                } catch (ex: Exception) {
+                    println("YouTube: failed to load id prefix cache: ${ex.message}")
+                }
+                prefixCacheLoaded = true
+            }
+        }
+
+        private fun persistPrefixCacheEntry(prefix: String, full: String) {
+            if (!prefixCachePersistenceEnabled) return
+            synchronized(prefixCacheLock) {
+                try {
+                    // Keep memory map authoritative; rewrite small cache file.
+                    prefixCache[prefix] = full
+                    File(PREFIX_CACHE_FILE).bufferedWriter().use { writer ->
+                        writer.write("# YouTube 10-char Traktor prefix -> 11-char video id\n")
+                        prefixCache.entries.sortedBy { it.key }.forEach { (key, value) ->
+                            writer.write("$key=$value\n")
+                        }
+                    }
+                } catch (ex: Exception) {
+                    println("YouTube: failed to persist id prefix cache: ${ex.message}")
+                }
+            }
+        }
+
+        /** Test helper: clear in-memory caches (does not delete the on-disk file). */
+        internal fun clearPrefixCacheForTests() {
+            prefixCache.clear()
+            ambiguousPrefixes.clear()
+            prefixInflight.clear()
+            prefixCacheLoaded = true // skip reloading disk during unit tests
+        }
+
+        internal fun bestThumbnailUrl(thumbnails: List<org.schabi.newpipe.extractor.Image>): String? {
+            return thumbnails
+                .maxByOrNull { thumb ->
+                    val w = if (thumb.width > 0) thumb.width else 0
+                    val h = if (thumb.height > 0) thumb.height else 0
+                    w * h
+                }
+                ?.url
+                ?.takeIf { it.isNotBlank() }
+        }
     }
 
     private fun getAudioStream(url: String): String {
@@ -93,11 +437,11 @@ class Youtube : ISource {
 
     class Downloader : org.schabi.newpipe.extractor.downloader.Downloader() {
 
-        private val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:68.0) Gecko/20100101 Firefox/68.0"
+        private val userAgent = "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:68.0) Gecko/20100101 Firefox/68.0"
 
         override fun execute(request: Request): Response {
             val headers = HashMap<String, String>()
-            headers["User-Agent"] = USER_AGENT
+            headers["User-Agent"] = userAgent
             request.headers().forEach { (k, v) -> headers[k] = v[0]}
 
             val con = WebRequests.createConnection(request.url(), request.httpMethod(), headers)

--- a/src/test/kotlin/CatalogRoutesTest.kt
+++ b/src/test/kotlin/CatalogRoutesTest.kt
@@ -1,0 +1,203 @@
+import beatport.api.Artist
+import beatport.api.GenreTrackResponse
+import beatport.api.Track
+import beatport.api.Utils
+import beatport.api.releaseWithArt
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsBytes
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CatalogRoutesTest {
+
+    private val json = Json {
+        isLenient = true
+        ignoreUnknownKeys = true
+    }
+
+    private fun cleanup(responses: List<beatport.api.TrackResponse>) {
+        responses.forEach { clearTrackMapping(it.id) }
+    }
+
+    @Test
+    fun catalogTracksById_returnsCachedTrackWithCoverProxyUrl() = testApplication {
+        application { module() }
+        val client = createClient {
+            install(ContentNegotiation) { json(json) }
+        }
+        val release = releaseWithArt(
+            "Album",
+            "https://cdn.example/route-art/400x400.jpg"
+        )
+        val responses = processTracks(
+            0,
+            listOf(Track("routecover1", listOf(Artist(1, "Artist")), "Route Track", 1234L, release))
+        )
+        try {
+            val id = responses[0].id
+            val response = client.get("/v4/catalog/tracks/?id=$id")
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.body<GenreTrackResponse>()
+            assertEquals(1, body.results.size)
+            assertEquals(id, body.results[0].id)
+            assertEquals("Route Track", body.results[0].name)
+            val expected = coverProxyUrl(id)
+            assertEquals(expected, body.results[0].image?.uri)
+            assertEquals(expected, body.results[0].release?.image?.uri)
+        } finally {
+            cleanup(responses)
+        }
+    }
+
+    @Test
+    fun catalogTracksById_emptyQueryReturnsEmptyResults() = testApplication {
+        application { module() }
+        val client = createClient {
+            install(ContentNegotiation) { json(json) }
+        }
+        val response = client.get("/v4/catalog/tracks/")
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.body<GenreTrackResponse>()
+        assertEquals(emptyList(), body.results)
+    }
+
+    @Test
+    fun catalogTracksById_unknownIdReturnsEmptyResults() = testApplication {
+        application { module() }
+        val client = createClient {
+            install(ContentNegotiation) { json(json) }
+        }
+        val response = client.get("/v4/catalog/tracks/?id=999999999")
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.body<GenreTrackResponse>()
+        assertEquals(emptyList(), body.results)
+    }
+
+    @Test
+    fun coverRoute_servesBytesAndContentType() = testApplication {
+        application { module() }
+        val previous = coverDownloader
+        val bytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47)
+        val release = releaseWithArt("Album", "https://cdn.example/route-cover/a.png")
+        val responses = processTracks(
+            0,
+            listOf(Track("routecover2", listOf(Artist(1, "Artist")), "Cover Track", 1000L, release))
+        )
+        try {
+            val id = responses[0].id
+            val origin = getCoverOriginUrl(id)!!
+            coverDownloader = { url ->
+                assertEquals(origin, url)
+                CoverDownload(bytes, ContentType.Image.PNG)
+            }
+            val response = client.get("/v4/catalog/tracks/$id/cover/")
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(ContentType.Image.PNG, response.contentType()?.withoutParameters())
+            assertTrue(response.bodyAsBytes().contentEquals(bytes))
+        } finally {
+            coverDownloader = previous
+            cleanup(responses)
+        }
+    }
+
+    @Test
+    fun coverRoute_usesCacheOnSecondRequest() = testApplication {
+        application { module() }
+        val previous = coverDownloader
+        var downloads = 0
+        val release = releaseWithArt("Album", "https://cdn.example/route-cover/cache.png")
+        val responses = processTracks(
+            0,
+            listOf(Track("routecover3", listOf(Artist(1, "Artist")), "Cache Track", 1000L, release))
+        )
+        try {
+            val id = responses[0].id
+            coverDownloader = {
+                downloads += 1
+                CoverDownload(byteArrayOf(1, 2, 3), ContentType.Image.JPEG)
+            }
+            assertEquals(HttpStatusCode.OK, client.get("/v4/catalog/tracks/$id/cover/").status)
+            assertEquals(HttpStatusCode.OK, client.get("/v4/catalog/tracks/$id/cover/").status)
+            assertEquals(1, downloads)
+        } finally {
+            coverDownloader = previous
+            cleanup(responses)
+        }
+    }
+
+    @Test
+    fun coverRoute_notFoundWithoutMapping() = testApplication {
+        application { module() }
+        val response = client.get("/v4/catalog/tracks/424242/cover/")
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun catalogTracksById_hydratesAfterMappingRemoved() = testApplication {
+        application { module() }
+        val client = createClient {
+            install(ContentNegotiation) { json(json) }
+        }
+        val nativeId = "routehydr1"
+        val track = Track(
+            nativeId,
+            listOf(Artist(1, "Artist")),
+            "Hydrate Route",
+            1000L,
+            releaseWithArt("Album", "https://cdn.example/route-cover/hydrate.jpg")
+        )
+        val fake = FakeLookupSource(mapOf(nativeId to track))
+        sources.add(fake)
+        val previousDownloader = coverDownloader
+        try {
+            val traktorId = Utils.encode(nativeId)
+            clearTrackMapping(traktorId)
+            coverDownloader = {
+                CoverDownload(byteArrayOf(1, 2, 3, 4), ContentType.Image.JPEG)
+            }
+            val response = client.get("/v4/catalog/tracks/?id=$traktorId")
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.body<GenreTrackResponse>()
+            assertEquals(1, body.results.size)
+            assertEquals(coverProxyUrl(traktorId), body.results[0].image?.uri)
+
+            val cover = client.get("/v4/catalog/tracks/$traktorId/cover/")
+            assertEquals(HttpStatusCode.OK, cover.status)
+            assertTrue(cover.bodyAsBytes().contentEquals(byteArrayOf(1, 2, 3, 4)))
+        } finally {
+            coverDownloader = previousDownloader
+            clearTrackMapping(Utils.encode(nativeId))
+            sources.remove(fake)
+        }
+    }
+
+    @Test
+    fun coverRoute_badGatewayWhenDownloadFails() = testApplication {
+        application { module() }
+        val previous = coverDownloader
+        val release = releaseWithArt("Album", "https://cdn.example/route-cover/fail.jpg")
+        val responses = processTracks(
+            0,
+            listOf(Track("routecover4", listOf(Artist(1, "Artist")), "Fail Track", 1000L, release))
+        )
+        try {
+            val id = responses[0].id
+            coverDownloader = { throw IOException("upstream down") }
+            val response = client.get("/v4/catalog/tracks/$id/cover/")
+            assertEquals(HttpStatusCode.BadGateway, response.status)
+        } finally {
+            coverDownloader = previous
+            cleanup(responses)
+        }
+    }
+}

--- a/src/test/kotlin/FakeLookupSource.kt
+++ b/src/test/kotlin/FakeLookupSource.kt
@@ -1,0 +1,17 @@
+import beatport.api.Playlist
+import beatport.api.Track
+import sources.ISource
+
+/** Minimal [ISource] that only implements [lookupTrack] for catalog hydration tests. */
+class FakeLookupSource(private val byId: Map<String, Track>) : ISource {
+    override val name: String = "FakeLookup"
+    override fun getGenre(): List<Track> = emptyList()
+    override fun getCuratedPlaylists(reset: Boolean): List<Playlist> = emptyList()
+    override fun getCuratedPlaylist(id: String): List<Track> = emptyList()
+    override fun getPlaylists(): List<Playlist> = emptyList()
+    override fun getPlaylist(id: String): List<Track> = emptyList()
+    override fun getTop100(): List<Track> = emptyList()
+    override fun query(query: String, reset: Boolean): List<Track> = emptyList()
+    override fun lookupTrack(id: String): Track? = byId[id]
+    override fun download(id: String): ByteArray = ByteArray(0)
+}

--- a/src/test/kotlin/MainLogicTest.kt
+++ b/src/test/kotlin/MainLogicTest.kt
@@ -1,0 +1,379 @@
+import beatport.api.Artist
+import beatport.api.Image
+import beatport.api.Track
+import beatport.api.TrackResponse
+import beatport.api.Utils
+import beatport.api.releaseWithArt
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import sources.ISource
+import sources.Youtube
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class MainLogicTest {
+
+    private fun cleanup(responses: List<TrackResponse>) {
+        responses.forEach { clearTrackMapping(it.id) }
+    }
+
+    private fun withFakeSource(source: ISource, block: (sourceIndex: Int) -> Unit) {
+        sources.add(source)
+        val index = sources.lastIndex
+        try {
+            block(index)
+        } finally {
+            sources.remove(source)
+        }
+    }
+
+    @Test
+    fun processTracks_cachesTrackResponse() {
+        val track = Track("abcdefghij", listOf(Artist(1, "Artist")), "Name", 1234L)
+        val responses = processTracks(0, listOf(track))
+        try {
+            assertEquals(1, responses.size)
+            assertEquals(Utils.encode("abcdefghij"), responses[0].id)
+            assertEquals("Name", responses[0].name)
+            assertEquals(responses[0], getStoredTrack(responses[0].id))
+        } finally {
+            cleanup(responses)
+        }
+    }
+
+    @Test
+    fun processTracks_propagatesCoverArtToResponse() {
+        val release = releaseWithArt(
+            "Album",
+            "https://cdn.example/art/400x400.jpg",
+            "https://cdn.example/art/{w}x{h}.jpg"
+        )
+        val track = Track("covertrack1", listOf(Artist(1, "Artist")), "Name", 1234L, release)
+        val responses = processTracks(0, listOf(track))
+        try {
+            assertEquals(1, responses.size)
+            val id = responses[0].id
+            val expected = coverProxyUrl(id)
+            assertEquals(expected, responses[0].image?.uri)
+            assertEquals(expected, responses[0].image?.dynamic_uri)
+            assertEquals(expected, responses[0].release?.image?.uri)
+            assertEquals("https://cdn.example/art/400x400.jpg", getCoverOriginUrl(id))
+        } finally {
+            cleanup(responses)
+        }
+    }
+
+    @Test
+    fun parseCatalogTrackIds_readsIdQueryUsedByTraktor() {
+        assertEquals(
+            listOf(42L, 99L),
+            parseCatalogTrackIds(io.ktor.http.parametersOf("id" to listOf("42", "99")))
+        )
+        assertEquals(
+            listOf(1L, 2L, 3L),
+            parseCatalogTrackIds(io.ktor.http.parametersOf("id" to listOf("1,2", "3")))
+        )
+        assertEquals(
+            emptyList(),
+            parseCatalogTrackIds(io.ktor.http.parametersOf())
+        )
+    }
+
+    @Test
+    fun isAllowedCoverOriginUrl_acceptsHttpsRemoteHosts() {
+        assertTrue(isAllowedCoverOriginUrl("https://avatars.yandex.net/get-music-content/abc/400x400"))
+        assertTrue(isAllowedCoverOriginUrl("https://i.ytimg.com/vi/x/hqdefault.jpg"))
+        assertTrue(isAllowedCoverOriginUrl(" https://cdn.example/art.jpg "))
+    }
+
+    @Test
+    fun isAllowedCoverOriginUrl_rejectsCleartextLocalAndPrivate() {
+        assertTrue(!isAllowedCoverOriginUrl("http://cdn.example/a.jpg"))
+        assertTrue(!isAllowedCoverOriginUrl("https://localhost/a.jpg"))
+        assertTrue(!isAllowedCoverOriginUrl("https://127.0.0.1/a.jpg"))
+        assertTrue(!isAllowedCoverOriginUrl("https://192.168.0.5/a.jpg"))
+        assertTrue(!isAllowedCoverOriginUrl("https://10.0.0.2/a.jpg"))
+        assertTrue(!isAllowedCoverOriginUrl("https://user:pass@cdn.example/a.jpg"))
+        assertTrue(!isAllowedCoverOriginUrl("not-a-url"))
+    }
+
+    @Test
+    fun coverContentType_prefersUpstreamImageMime() {
+        assertEquals(io.ktor.http.ContentType.Image.JPEG, coverContentType(null))
+        assertEquals(io.ktor.http.ContentType.Image.JPEG, coverContentType("image/jpg"))
+        assertEquals(io.ktor.http.ContentType.Image.PNG, coverContentType("image/png; charset=binary"))
+        assertEquals(io.ktor.http.ContentType.parse("image/webp"), coverContentType("image/webp"))
+        assertEquals(io.ktor.http.ContentType.Image.JPEG, coverContentType("text/html"))
+    }
+
+    @Test
+    fun resolveCoverRedirectUrl_allowsHttpsRemoteAndResolvesRelative() {
+        assertEquals(
+            "https://cdn.example/b.jpg",
+            resolveCoverRedirectUrl("https://cdn.example/a.jpg", "https://cdn.example/b.jpg")
+        )
+        assertEquals(
+            "https://cdn.example/art/b.jpg",
+            resolveCoverRedirectUrl("https://cdn.example/art/a.jpg", "b.jpg")
+        )
+        assertEquals(
+            "https://cdn.example/other.jpg",
+            resolveCoverRedirectUrl("https://cdn.example/art/a.jpg", "/other.jpg")
+        )
+    }
+
+    @Test
+    fun resolveCoverRedirectUrl_rejectsCleartextLocalAndPrivate() {
+        assertNull(resolveCoverRedirectUrl("https://cdn.example/a.jpg", "http://cdn.example/b.jpg"))
+        assertNull(resolveCoverRedirectUrl("https://cdn.example/a.jpg", "https://127.0.0.1/b.jpg"))
+        assertNull(resolveCoverRedirectUrl("https://cdn.example/a.jpg", "https://192.168.0.5/b.jpg"))
+        assertNull(resolveCoverRedirectUrl("https://cdn.example/a.jpg", "https://localhost/b.jpg"))
+        assertNull(resolveCoverRedirectUrl("https://cdn.example/a.jpg", "//127.0.0.1/b.jpg"))
+    }
+
+    @Test
+    fun processTracks_ignoresDisallowedCoverOrigin() {
+        val release = releaseWithArt("Album", "http://cdn.example/art.jpg")
+        val track = Track("badcover01", listOf(Artist(1, "Artist")), "Name", 1L, release)
+        val responses = processTracks(0, listOf(track))
+        try {
+            assertEquals(1, responses.size)
+            assertEquals(null, responses[0].image)
+            assertEquals(null, responses[0].release?.image)
+            assertEquals(null, getCoverOriginUrl(responses[0].id))
+        } finally {
+            cleanup(responses)
+        }
+    }
+
+    @Test
+    fun apiJson_encodesDefaultsButOmitsNullArtwork() {
+        val withArt = TrackResponse(
+            id = 42L,
+            artists = listOf(Artist(1, "Artist")),
+            name = "Named",
+            length_ms = 1000L,
+            release = releaseWithArt("Album", "https://cdn.example/a.jpg"),
+            image = Image(id = 42L, uri = "https://api.beatport.com/cover", dynamic_uri = "https://api.beatport.com/cover")
+        )
+        val withArtJson = apiJson.encodeToString(TrackResponse.serializer(), withArt)
+        val withArtObj = Json.parseToJsonElement(withArtJson).jsonObject
+        assertEquals("Named", withArtObj["name"]?.jsonPrimitive?.content)
+        assertEquals(0L, withArtObj["release"]!!.jsonObject["id"]!!.jsonPrimitive.content.toLong())
+        assertEquals(
+            "https://cdn.example/a.jpg",
+            withArtObj["release"]!!.jsonObject["image"]!!.jsonObject["uri"]!!.jsonPrimitive.content
+        )
+        assertEquals(
+            "https://api.beatport.com/cover",
+            withArtObj["image"]!!.jsonObject["uri"]!!.jsonPrimitive.content
+        )
+
+        val noArt = TrackResponse(
+            id = 43L,
+            artists = listOf(Artist(1, "Artist")),
+            name = "Bare",
+            length_ms = 1000L,
+            release = beatport.api.Release(name = "Bare"),
+            image = null
+        )
+        val noArtJson = apiJson.encodeToString(TrackResponse.serializer(), noArt)
+        val noArtObj = Json.parseToJsonElement(noArtJson).jsonObject
+        assertFalse(noArtObj.containsKey("image"))
+        assertFalse(noArtObj["release"]!!.jsonObject.containsKey("image"))
+        assertFalse(noArtObj["release"]!!.jsonObject.containsKey("label"))
+        assertEquals("Bare", noArtObj["release"]!!.jsonObject["name"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun ensureCatalogTrack_hydratesMissingMappingWithCover() {
+        val nativeId = "hydrate01"
+        val withArt = Track(
+            nativeId,
+            listOf(Artist(1, "Artist")),
+            "Hydrated",
+            1000L,
+            releaseWithArt("Album", "https://cdn.example/hydrate/art.jpg")
+        )
+        withFakeSource(FakeLookupSource(mapOf(nativeId to withArt))) { sourceIndex ->
+            val traktorId = Utils.encode(nativeId)
+            clearTrackMapping(traktorId)
+            val ensured = ensureCatalogTrack(traktorId)
+            try {
+                assertEquals(traktorId, ensured!!.id)
+                assertEquals(coverProxyUrl(traktorId), ensured.image?.uri)
+                assertEquals(
+                    "https://cdn.example/hydrate/art.jpg",
+                    getCoverOriginUrl(traktorId)
+                )
+                assertEquals(sourceIndex, trackIdToSource[nativeId])
+            } finally {
+                clearTrackMapping(traktorId)
+            }
+        }
+    }
+
+    @Test
+    fun ensureCatalogTrack_backfillsCoverForMappedTrackWithoutArt() {
+        val nativeId = "hydrate02"
+        val bare = Track(nativeId, listOf(Artist(1, "Artist")), "Bare", 1000L)
+        val withArt = Track(
+            nativeId,
+            listOf(Artist(1, "Artist")),
+            "Bare",
+            1000L,
+            releaseWithArt("Album", "https://cdn.example/hydrate/backfill.jpg")
+        )
+        withFakeSource(FakeLookupSource(mapOf(nativeId to withArt))) { sourceIndex ->
+            val responses = processTracks(sourceIndex, listOf(bare))
+            try {
+                val id = responses[0].id
+                assertEquals(null, getCoverOriginUrl(id))
+                val ensured = ensureCatalogTrack(id)
+                assertEquals(coverProxyUrl(id), ensured!!.image?.uri)
+                assertEquals(
+                    "https://cdn.example/hydrate/backfill.jpg",
+                    getCoverOriginUrl(id)
+                )
+            } finally {
+                cleanup(responses)
+            }
+        }
+    }
+
+    @Test
+    fun mergeCatalogLookup_preservesTitleAndDurationOnPlaceholderLookup() {
+        val existing = TrackResponse(
+            id = 1L,
+            artists = listOf(Artist(1, "Real Artist")),
+            name = "Real Title",
+            length_ms = 240_000L,
+            release = beatport.api.Release(name = "Real Title")
+        )
+        val lookedUp = Track(
+            "dQw4w9WgXcQ",
+            listOf(Artist(1, "YouTube")),
+            "dQw4w9WgXcQ",
+            0L,
+            releaseWithArt("dQw4w9WgXcQ", "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg")
+        )
+        val merged = mergeCatalogLookup(existing, lookedUp)
+        assertEquals("Real Title", merged.name)
+        assertEquals(240_000L, merged.length_ms)
+        assertEquals("Real Artist", merged.artists.single().name)
+        assertEquals("https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg", merged.release.image?.uri)
+        assertEquals("dQw4w9WgXcQ", merged.id)
+    }
+
+    @Test
+    fun ensureCatalogTrack_doesNotClobberMetaWhenLookupIsPlaceholder() {
+        val nativeId = "hydrate03"
+        val bare = Track(nativeId, listOf(Artist(1, "Keeper")), "Keep Name", 12_345L)
+        val placeholder = Track(
+            nativeId,
+            listOf(Artist(1, "YouTube")),
+            nativeId,
+            0L,
+            releaseWithArt(nativeId, "https://cdn.example/hydrate/keep.jpg")
+        )
+        withFakeSource(FakeLookupSource(mapOf(nativeId to placeholder))) { sourceIndex ->
+            val responses = processTracks(sourceIndex, listOf(bare))
+            try {
+                val id = responses[0].id
+                val ensured = ensureCatalogTrack(id)!!
+                assertEquals("Keep Name", ensured.name)
+                assertEquals(12_345L, ensured.length_ms)
+                assertEquals("Keeper", ensured.artists.single().name)
+                assertEquals(coverProxyUrl(id), ensured.image?.uri)
+            } finally {
+                cleanup(responses)
+            }
+        }
+    }
+
+    @Test
+    fun ensureCatalogTrack_doesNotMisattributeSpotifyPrefixToYouTubePolicy() {
+        val youtubePolicySource = object : ISource by FakeLookupSource(emptyMap()) {
+            override val name: String = "YouTube"
+            override fun lookupTrack(id: String): Track? {
+                val videoId = Youtube.resolveVideoIdFromPrefix(id, allowNetworkExpand = false)
+                    ?: return null
+                return Track(
+                    videoId,
+                    listOf(Artist(1, "YouTube")),
+                    videoId,
+                    0L,
+                    releaseWithArt(videoId, Youtube.thumbnailUrl(videoId))
+                )
+            }
+        }
+        Youtube.prefixCachePersistenceEnabled = false
+        Youtube.clearPrefixCacheForTests()
+        Youtube.thumbnailProbe = { id -> id.startsWith("4uLU6hMCjM") }
+        withFakeSource(youtubePolicySource) {
+            val spotifyPrefix = "4uLU6hMCjM"
+            val traktorId = Utils.encode(spotifyPrefix)
+            clearTrackMapping(traktorId)
+            try {
+                assertNull(ensureCatalogTrack(traktorId))
+                assertNull(getCoverOriginUrl(traktorId))
+            } finally {
+                clearTrackMapping(traktorId)
+                Youtube.thumbnailProbe = Youtube::probeThumbnailExists
+                Youtube.clearPrefixCacheForTests()
+            }
+        }
+    }
+
+    @Test
+    fun coverCache_putAndGet() {
+        val cache = CoverCache(maxSize = 2)
+        val jpeg = io.ktor.http.ContentType.Image.JPEG
+        cache.put("https://cdn.example/a.jpg", CoverDownload(byteArrayOf(1, 2), jpeg))
+        cache.put("https://cdn.example/b.jpg", CoverDownload(byteArrayOf(3, 4), jpeg))
+        assertTrue(cache.get("https://cdn.example/a.jpg")!!.bytes.contentEquals(byteArrayOf(1, 2)))
+        assertEquals(jpeg, cache.get("https://cdn.example/b.jpg")!!.contentType)
+        assertEquals(null, cache.get("https://cdn.example/missing.jpg"))
+    }
+
+    @Test
+    fun coverCache_evictsEldest() {
+        val cache = CoverCache(maxSize = 2)
+        val jpeg = io.ktor.http.ContentType.Image.JPEG
+        cache.put("https://cdn.example/1.jpg", CoverDownload(byteArrayOf(1), jpeg))
+        cache.put("https://cdn.example/2.jpg", CoverDownload(byteArrayOf(2), jpeg))
+        cache.put("https://cdn.example/3.jpg", CoverDownload(byteArrayOf(3), jpeg))
+        assertEquals(2, cache.size())
+        assertEquals(null, cache.get("https://cdn.example/1.jpg"))
+        assertTrue(cache.get("https://cdn.example/2.jpg")!!.bytes.contentEquals(byteArrayOf(2)))
+        assertTrue(cache.get("https://cdn.example/3.jpg")!!.bytes.contentEquals(byteArrayOf(3)))
+    }
+
+    @Test
+    fun coverCache_getReturnsDefensiveCopy() {
+        val cache = CoverCache(maxSize = 2)
+        val original = byteArrayOf(9, 8, 7)
+        cache.put("https://cdn.example/x.jpg", CoverDownload(original, io.ktor.http.ContentType.Image.JPEG))
+        original[0] = 0
+        assertEquals(9, cache.get("https://cdn.example/x.jpg")!!.bytes[0])
+        val got = cache.get("https://cdn.example/x.jpg")!!.bytes
+        got[0] = 1
+        assertEquals(9, cache.get("https://cdn.example/x.jpg")!!.bytes[0])
+    }
+
+    @Test
+    fun coverCache_evictsByTotalByteSize() {
+        val cache = CoverCache(maxSize = 5, maxBytes = 3)
+        val jpeg = io.ktor.http.ContentType.Image.JPEG
+        cache.put("https://cdn.example/1.jpg", CoverDownload(byteArrayOf(1, 2), jpeg))
+        cache.put("https://cdn.example/2.jpg", CoverDownload(byteArrayOf(3, 4), jpeg))
+
+        assertEquals(null, cache.get("https://cdn.example/1.jpg"))
+        assertTrue(cache.get("https://cdn.example/2.jpg")!!.bytes.contentEquals(byteArrayOf(3, 4)))
+        assertEquals(2L, cache.byteSize())
+    }
+}

--- a/src/test/kotlin/sources/YoutubeLookupTest.kt
+++ b/src/test/kotlin/sources/YoutubeLookupTest.kt
@@ -1,0 +1,155 @@
+package sources
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class YoutubeLookupTest {
+
+    @AfterTest
+    fun tearDown() {
+        Youtube.thumbnailProbe = Youtube::probeThumbnailExists
+        Youtube.prefixCachePersistenceEnabled = true
+        Youtube.clearPrefixCacheForTests()
+    }
+
+    @Test
+    fun isYouTubeVideoId_requiresElevenAlphabetChars() {
+        assertTrue(Youtube.isYouTubeVideoId("dQw4w9WgXcQ"))
+        assertTrue(Youtube.isYouTubeVideoId("afSgBNwmZr_"))
+        assertFalse(Youtube.isYouTubeVideoId("afSgBNwmZr")) // truncated decode (10)
+        assertFalse(Youtube.isYouTubeVideoId("104791279"))
+        assertFalse(Youtube.isYouTubeVideoId(""))
+    }
+
+    @Test
+    fun isYouTubeVideoIdPrefix_acceptsTenChars() {
+        assertTrue(Youtube.isYouTubeVideoIdPrefix("dQw4w9WgXc"))
+        assertTrue(Youtube.isYouTubeVideoIdPrefix("afSgBNwmZr"))
+        assertFalse(Youtube.isYouTubeVideoIdPrefix("dQw4w9WgXcQ"))
+        assertFalse(Youtube.isYouTubeVideoIdPrefix("short"))
+    }
+
+    @Test
+    fun thumbnailUrl_usesIytimgCdn() {
+        assertEquals(
+            "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+            Youtube.thumbnailUrl("dQw4w9WgXcQ")
+        )
+    }
+
+    @Test
+    fun resolveVideoIdFromPrefix_passthroughFullId() {
+        assertEquals("dQw4w9WgXcQ", Youtube.resolveVideoIdFromPrefix("dQw4w9WgXcQ"))
+        assertNull(Youtube.resolveVideoIdFromPrefix("104791279"))
+        assertNull(Youtube.resolveVideoIdFromPrefix("short"))
+    }
+
+    @Test
+    fun resolveVideoIdFromPrefix_defaultDoesNotNetworkExpand() {
+        Youtube.prefixCachePersistenceEnabled = false
+        Youtube.clearPrefixCacheForTests()
+        var probes = 0
+        Youtube.thumbnailProbe = {
+            probes += 1
+            true
+        }
+        // Spotify-like 10-char prefix must not be guessed as YouTube via i.ytimg.
+        assertNull(Youtube.resolveVideoIdFromPrefix("4uLU6hMCjM"))
+        assertNull(Youtube.resolveVideoIdFromPrefix("4uLU6hMCjM", allowNetworkExpand = false))
+        assertEquals(0, probes)
+    }
+
+    @Test
+    fun rememberVideoId_allowsColdPrefixResolveWithoutExpand() {
+        Youtube.prefixCachePersistenceEnabled = false
+        Youtube.clearPrefixCacheForTests()
+        var probes = 0
+        Youtube.thumbnailProbe = {
+            probes += 1
+            false
+        }
+        Youtube.rememberVideoId("dQw4w9WgXcQ")
+        assertEquals("dQw4w9WgXcQ", Youtube.resolveVideoIdFromPrefix("dQw4w9WgXc"))
+        assertEquals(0, probes)
+    }
+
+    @Test
+    fun resolveVideoIdFromPrefix_singleFlightSharesOneExpand() {
+        Youtube.prefixCachePersistenceEnabled = false
+        Youtube.clearPrefixCacheForTests()
+        val probes = AtomicInteger(0)
+        val releaseProbes = CountDownLatch(1)
+        Youtube.thumbnailProbe = { id ->
+            probes.incrementAndGet()
+            // Block until both callers have entered resolve, so the second joins in-flight.
+            releaseProbes.await(2, TimeUnit.SECONDS)
+            id == "dQw4w9WgXcQ"
+        }
+
+        val pool = Executors.newFixedThreadPool(2)
+        try {
+            val started = CountDownLatch(2)
+            val f1 = pool.submit<String?> {
+                started.countDown()
+                started.await(2, TimeUnit.SECONDS)
+                Youtube.resolveVideoIdFromPrefix("dQw4w9WgXc", allowNetworkExpand = true)
+            }
+            val f2 = pool.submit<String?> {
+                started.countDown()
+                started.await(2, TimeUnit.SECONDS)
+                Youtube.resolveVideoIdFromPrefix("dQw4w9WgXc", allowNetworkExpand = true)
+            }
+            // Both threads are inside resolve; allow probes to finish.
+            Thread.sleep(50)
+            releaseProbes.countDown()
+            assertEquals("dQw4w9WgXcQ", f1.get(5, TimeUnit.SECONDS))
+            assertEquals("dQw4w9WgXcQ", f2.get(5, TimeUnit.SECONDS))
+        } finally {
+            pool.shutdownNow()
+        }
+
+        // One expand = at most one full alphabet sweep (64), not two (128).
+        assertTrue(probes.get() in 1..64, "probes=${probes.get()}")
+        // Cached second call must not probe again (even without allowNetworkExpand).
+        val before = probes.get()
+        assertEquals("dQw4w9WgXcQ", Youtube.resolveVideoIdFromPrefix("dQw4w9WgXc"))
+        assertEquals(before, probes.get())
+    }
+
+    @Test
+    fun resolveVideoIdFromPrefix_ambiguousWhenMultipleHits() {
+        Youtube.prefixCachePersistenceEnabled = false
+        Youtube.clearPrefixCacheForTests()
+        Youtube.thumbnailProbe = { id ->
+            id == "dQw4w9WgXcQ" || id == "dQw4w9WgXcX"
+        }
+        assertNull(Youtube.resolveVideoIdFromPrefix("dQw4w9WgXc", allowNetworkExpand = true))
+        // Negative cache: do not probe again.
+        var probes = 0
+        Youtube.thumbnailProbe = {
+            probes += 1
+            false
+        }
+        assertNull(Youtube.resolveVideoIdFromPrefix("dQw4w9WgXc", allowNetworkExpand = true))
+        assertEquals(0, probes)
+    }
+
+    @Test
+    fun resolveVideoIdFromPrefix_uniqueHitOnly() {
+        Youtube.prefixCachePersistenceEnabled = false
+        Youtube.clearPrefixCacheForTests()
+        Youtube.thumbnailProbe = { id -> id == "afSgBNwmZrQ" }
+        assertEquals(
+            "afSgBNwmZrQ",
+            Youtube.resolveVideoIdFromPrefix("afSgBNwmZr", allowNetworkExpand = true)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Makes track artwork show up in Traktor for YouTube, Spotify, and Tidal.

This continues the idea from [#3](https://github.com/0xf4b1/traktor-streaming-proxy/pull/3) (`Release` / `Label` on tracks), which was meant to display covers but did not work end-to-end. The approach here is based on the Beatport catalog/image shape documented in [kemo’s Beatport API notes](https://gist.github.com/kemo/506ca56e35b9506ee5233bc4d773c1c8) (`image.uri` / `image.dynamic_uri`, nested `release.image`).

Verified working in Traktor against this branch:
https://github.com/0xf4b1/traktor-streaming-proxy/compare/master...jekakmail:traktor-streaming-proxy:feat/cover-art

## What changed
- Add Beatport-shaped `Image` / `Release` / `Label` fields on catalog track payloads
- Propagate artwork URLs from Spotify, Tidal, and YouTube sources
- Proxy covers through `GET /v4/catalog/tracks/{id}/cover/` (HTTPS, redirect-safe allowlist, small LRU cache)
- Hydrate catalog metadata via `GET /v4/catalog/tracks/?id=…` and `lookupTrack` when mappings are cold
- YouTube: persist 10→11 char id prefix cache; do **not** blindly expand prefixes on cross-source fan-out (avoids Spotify/Tidal mis-attribution)
- JSON: `encodeDefaults = true`, omit null art fields via `explicitNulls = false`

<img width="1708" height="1077" alt="Снимок экрана — 2026-08-08 в 14 55 53" src="https://github.com/user-attachments/assets/3913fce0-62f5-47d7-a94f-145b39a381e1" />

## Test plan
- [x] `./gradlew test`
- [x] Manual Traktor check: search / browse tracks → covers load
- [x] After proxy restart: YouTube covers still resolve (prefix cache)
- [ ] After proxy restart: Spotify / Tidal covers still resolve